### PR TITLE
Feat/leviathan state test frontier add opecode

### DIFF
--- a/src/evm/evm.rs
+++ b/src/evm/evm.rs
@@ -65,7 +65,6 @@ impl EVM {
         self.gas = U256::ZERO;
         return gas;
     }
-
 }
 
 impl Xi for EVM {
@@ -257,11 +256,15 @@ mod tests {
                         evm.gas = evm.gas.saturating_add(actual_refund);
                     }
                     Err(None) => {
-                        leviathan.roleback(&mut state).expect("ロールバックに失敗しました");
+                        leviathan
+                            .roleback(&mut state)
+                            .expect("ロールバックに失敗しました");
                         evm.gas = U256::ZERO;
                     }
                     Err(Some(_)) => {
-                        leviathan.roleback(&mut state).expect("ロールバックに失敗しました");
+                        leviathan
+                            .roleback(&mut state)
+                            .expect("ロールバックに失敗しました");
                     }
                 }
 

--- a/src/evm/evm.rs
+++ b/src/evm/evm.rs
@@ -124,7 +124,7 @@ mod tests {
     use crate::leviathan::leviathan::LEVIATHAN;
     use crate::leviathan::structs::{BlockHeader, ExecutionEnvironment, SubState, VersionId};
     use crate::leviathan::world_state::{Account, Address, WorldState};
-    use crate::my_trait::leviathan_trait::TransactionExecution;
+    use crate::my_trait::leviathan_trait::{RoleBack, TransactionExecution};
 
     // パーサーをインポート
     use crate::my_trait::evm_trait::Xi;
@@ -256,11 +256,11 @@ mod tests {
                         evm.gas = evm.gas.saturating_add(actual_refund);
                     }
                     Err(None) => {
-                        state = build_initial_state();
+                        leviathan.roleback(&mut state).expect("ロールバックに失敗しました");
                         evm.gas = U256::ZERO;
                     }
                     Err(Some(_)) => {
-                        state = build_initial_state();
+                        leviathan.roleback(&mut state).expect("ロールバックに失敗しました");
                     }
                 }
 

--- a/src/evm/evm.rs
+++ b/src/evm/evm.rs
@@ -65,6 +65,7 @@ impl EVM {
         self.gas = U256::ZERO;
         return gas;
     }
+
 }
 
 impl Xi for EVM {

--- a/src/evm/execution.rs
+++ b/src/evm/execution.rs
@@ -6,7 +6,7 @@ use crate::leviathan::roleback::Action;
 use crate::leviathan::structs::{ExecutionEnvironment, Log, SubState, VersionId};
 use crate::leviathan::world_state::{Account, Address, WorldState};
 use crate::my_trait::evm_trait::{Gfunction, Ofunction, Xi};
-use crate::my_trait::leviathan_trait::{State, MessageCall, ContractCreation};
+use crate::my_trait::leviathan_trait::{ContractCreation, MessageCall, State};
 use alloy_primitives::{I256, U256};
 use sha3::{Digest, Keccak256};
 
@@ -431,8 +431,8 @@ impl Ofunction for EVM {
             0x37 => {
                 //CALLDATACOPY
                 let data = &execution_environment.i_data;
-                let dest_offset = self.pop().try_into().unwrap_or(usize::MAX);  //メモリ
-                let offset = self.pop().try_into().unwrap_or(usize::MAX);   //CALLDATA
+                let dest_offset = self.pop().try_into().unwrap_or(usize::MAX); //メモリ
+                let offset = self.pop().try_into().unwrap_or(usize::MAX); //CALLDATA
                 let size = self.pop().try_into().unwrap_or(usize::MAX);
                 //メモリ拡張
                 if size != 0 {
@@ -442,14 +442,14 @@ impl Ofunction for EVM {
                         self.memory.resize(words * 32, 0);
                     }
                     //メモリに値を書き込む
-                    let mut slice = vec![0u8;size];
+                    let mut slice = vec![0u8; size];
                     let read_size = offset.saturating_add(size);
                     if offset <= data.len() {
                         if read_size > data.len() {
                             let copy_len = data.len() - offset;
                             slice[..copy_len].copy_from_slice(&data[offset..data.len()]);
                         } else {
-                                slice.copy_from_slice(&data[offset..read_size]);
+                            slice.copy_from_slice(&data[offset..read_size]);
                         }
                     }
                     self.memory[dest_offset..required_size].copy_from_slice(&slice);
@@ -777,14 +777,20 @@ impl Ofunction for EVM {
                     .get(&key)
                     .cloned()
                     .unwrap();
-                
+
                 //払い戻し
                 if self.version == VersionId::Frontier {
                     if !pre_value.is_zero() && value.is_zero() {
                         substate.a_reimburse += 15000;
                     }
-                }else{
-                    let val0 = substate.a_access_storage.get(&address).unwrap().get(&key).cloned().unwrap_or(U256::ZERO);
+                } else {
+                    let val0 = substate
+                        .a_access_storage
+                        .get(&address)
+                        .unwrap()
+                        .get(&key)
+                        .cloned()
+                        .unwrap_or(U256::ZERO);
                     if pre_value != value {
                         if val0 == pre_value {
                             if val0 != U256::ZERO && value == U256::ZERO {
@@ -913,9 +919,10 @@ impl Ofunction for EVM {
                 self.active_words = active_words;
             }
 
-            0xf1 => {   //CALL
-                let gas = self.pop();   //サブコールに割り当てる最大ガス
-                let to = self.pop();    //呼び出し先のアドレス
+            0xf1 => {
+                //CALL
+                let gas = self.pop(); //サブコールに割り当てる最大ガス
+                let to = self.pop(); //呼び出し先のアドレス
                 let to_address = Address::from_u256(to);
                 let value = self.pop();
                 let in_offset = self.pop().try_into().unwrap_or(usize::MAX);
@@ -944,29 +951,33 @@ impl Ofunction for EVM {
                     let required_size = in_offset.saturating_add(in_size);
                     let slice = &self.memory[in_offset..required_size];
                     data = slice.to_vec();
-                }else{
+                } else {
                     data = Vec::<u8>::new();
                 }
                 //事前チェック
-                let my_balance = state.get_balance(&execution_environment.i_address).unwrap_or(U256::from(0));
-                if my_balance < value ||  execution_environment.i_depth >= 1024 {
+                let my_balance = state
+                    .get_balance(&execution_environment.i_address)
+                    .unwrap_or(U256::from(0));
+                if my_balance < value || execution_environment.i_depth >= 1024 {
                     self.push(U256::ZERO);
-                    return None
+                    return None;
                 }
                 //サブコールの実行
                 let depth = execution_environment.i_depth + 1;
                 //子に渡すガスの計算
-                let gr = self.gas;    //利用可能ガス
-                let gr = gr - (gr / U256::from(64));        //渡せる上限
-                let mut child_gas = if gr > gas {       //スタックの指定値と渡せる上限を比較
+                let gr = self.gas; //利用可能ガス
+                let gr = gr - (gr / U256::from(64)); //渡せる上限
+                let mut child_gas = if gr > gas {
+                    //スタックの指定値と渡せる上限を比較
                     gas
                 } else {
                     gr
                 };
                 //親のガスから，子に渡すベース分を引く
                 self.gas = self.gas.saturating_sub(child_gas);
-                let child_gas = if value > 0 {      //最終的な子に渡すガス
-                    child_gas.saturating_add(U256::from(2300))      //送金額が0よりも大きい
+                let child_gas = if value > 0 {
+                    //最終的な子に渡すガス
+                    child_gas.saturating_add(U256::from(2300)) //送金額が0よりも大きい
                 } else {
                     child_gas
                 };
@@ -987,19 +998,19 @@ impl Ofunction for EVM {
                     depth,
                     execution_environment.i_permission,
                     execution_environment.i_block_header,
-                    );
+                );
 
                 //実行後の処理
                 match result {
                     Ok((return_gas, return_data)) => {
                         //出力データのメモリ書き込み
                         let return_size = return_data.len();
-                        let write_size = out_size.min(return_size);  //書き込みサイズ
-                        if write_size >0 {
+                        let write_size = out_size.min(return_size); //書き込みサイズ
+                        if write_size > 0 {
                             let required_size = out_offset.saturating_add(write_size);
                             self.memory[out_offset..required_size]
-                            .copy_from_slice(&return_data[..write_size]);
-                            let active_words = self.memory.len() / 32;      //アクティブなword数を更新
+                                .copy_from_slice(&return_data[..write_size]);
+                            let active_words = self.memory.len() / 32; //アクティブなword数を更新
                             self.active_words = active_words;
                         }
                         //Returndata バッファの更新
@@ -1014,17 +1025,17 @@ impl Ofunction for EVM {
                         leviathan.merge(child_leviathan);
                         //結果push
                         self.push(U256::from(1));
-                    },
+                    }
 
                     Err((return_gas, Some(return_data))) => {
                         //出力データのメモリ書き込み
                         let return_size = return_data.len();
-                        let write_size = out_size.min(return_size);  //書き込みサイズ
-                        if write_size >0 {
+                        let write_size = out_size.min(return_size); //書き込みサイズ
+                        if write_size > 0 {
                             let required_size = out_offset.saturating_add(write_size);
                             self.memory[out_offset..required_size]
-                            .copy_from_slice(&return_data[..write_size]);
-                            let active_words = self.memory.len() / 32;      //アクティブなword数を更新
+                                .copy_from_slice(&return_data[..write_size]);
+                            let active_words = self.memory.len() / 32; //アクティブなword数を更新
                             self.active_words = active_words;
                         }
                         //Returndata バッファの更新
@@ -1037,8 +1048,7 @@ impl Ofunction for EVM {
                         }
                         //結果push
                         self.push(U256::ZERO);
-
-                    },
+                    }
 
                     Err((return_gas, None)) => {
                         //アクセス済みリストの更新
@@ -1047,11 +1057,8 @@ impl Ofunction for EVM {
                         }
                         //結果push
                         self.push(U256::ZERO);
-                    },
+                    }
                 }
-
-
-
             }
 
             0xf3 => {

--- a/src/evm/execution.rs
+++ b/src/evm/execution.rs
@@ -6,7 +6,7 @@ use crate::leviathan::roleback::Action;
 use crate::leviathan::structs::{ExecutionEnvironment, Log, SubState, VersionId};
 use crate::leviathan::world_state::{Account, Address, WorldState};
 use crate::my_trait::evm_trait::{Gfunction, Ofunction, Xi};
-use crate::my_trait::leviathan_trait::State;
+use crate::my_trait::leviathan_trait::{State, MessageCall, ContractCreation};
 use alloy_primitives::{I256, U256};
 use sha3::{Digest, Keccak256};
 
@@ -911,6 +911,147 @@ impl Ofunction for EVM {
                 //アクティブなword数を更新
                 let active_words = self.memory.len() / 32;
                 self.active_words = active_words;
+            }
+
+            0xf1 => {   //CALL
+                let gas = self.pop();   //サブコールに割り当てる最大ガス
+                let to = self.pop();    //呼び出し先のアドレス
+                let to_address = Address::from_u256(to);
+                let value = self.pop();
+                let in_offset = self.pop().try_into().unwrap_or(usize::MAX);
+                let in_size = self.pop().try_into().unwrap_or(usize::MAX);
+                let out_offset = self.pop().try_into().unwrap_or(usize::MAX);
+                let out_size = self.pop().try_into().unwrap_or(usize::MAX);
+                //メモリ拡張コスト
+                let in_end = if in_size == 0 {
+                    0
+                } else {
+                    in_offset.saturating_add(in_size)
+                };
+
+                let out_end = if out_size == 0 {
+                    0
+                } else {
+                    out_offset.saturating_add(out_size)
+                };
+                let max_end = in_end.max(out_end);
+                let mut data = Vec::<u8>::new();
+                if max_end > self.memory.len() {
+                    let words = max_end.saturating_add(31) / 32;
+                    self.memory.resize(words.saturating_mul(32), 0);
+                }
+                if in_size > 0 {
+                    let required_size = in_offset.saturating_add(in_size);
+                    let slice = &self.memory[in_offset..required_size];
+                    data = slice.to_vec();
+                }else{
+                    data = Vec::<u8>::new();
+                }
+                //事前チェック
+                let my_balance = state.get_balance(&execution_environment.i_address).unwrap_or(U256::from(0));
+                if my_balance < value ||  execution_environment.i_depth >= 1024 {
+                    self.push(U256::ZERO);
+                    return None
+                }
+                //サブコールの実行
+                let depth = execution_environment.i_depth + 1;
+                //子に渡すガスの計算
+                let gr = self.gas;    //利用可能ガス
+                let gr = gr - (gr / U256::from(64));        //渡せる上限
+                let mut child_gas = if gr > gas {       //スタックの指定値と渡せる上限を比較
+                    gas
+                } else {
+                    gr
+                };
+                //親のガスから，子に渡すベース分を引く
+                self.gas = self.gas.saturating_sub(child_gas);
+                let child_gas = if value > 0 {      //最終的な子に渡すガス
+                    child_gas.saturating_add(U256::from(2300))      //送金額が0よりも大きい
+                } else {
+                    child_gas
+                };
+
+                let mut child_leviathan = LEVIATHAN::new(self.version);
+                let result = child_leviathan.message_call(
+                    state,
+                    substate,
+                    execution_environment.i_address.clone(),
+                    execution_environment.i_address.clone(),
+                    to_address.clone(),
+                    to_address.clone(),
+                    child_gas,
+                    execution_environment.i_gas_price,
+                    value,
+                    value,
+                    data,
+                    depth,
+                    execution_environment.i_permission,
+                    execution_environment.i_block_header,
+                    );
+
+                //実行後の処理
+                match result {
+                    Ok((return_gas, return_data)) => {
+                        //出力データのメモリ書き込み
+                        let return_size = return_data.len();
+                        let write_size = out_size.min(return_size);  //書き込みサイズ
+                        if write_size >0 {
+                            let required_size = out_offset.saturating_add(write_size);
+                            self.memory[out_offset..required_size]
+                            .copy_from_slice(&return_data[..write_size]);
+                            let active_words = self.memory.len() / 32;      //アクティブなword数を更新
+                            self.active_words = active_words;
+                        }
+                        //Returndata バッファの更新
+                        self.return_back = return_data;
+                        //ガスの精算
+                        self.gas = self.gas + return_gas;
+                        //アクセス済みリストの更新
+                        if !substate.a_access.contains(&to_address) {
+                            substate.a_access.push(to_address.clone())
+                        }
+                        //Journalのmerge
+                        leviathan.merge(child_leviathan);
+                        //結果push
+                        self.push(U256::from(1));
+                    },
+
+                    Err((return_gas, Some(return_data))) => {
+                        //出力データのメモリ書き込み
+                        let return_size = return_data.len();
+                        let write_size = out_size.min(return_size);  //書き込みサイズ
+                        if write_size >0 {
+                            let required_size = out_offset.saturating_add(write_size);
+                            self.memory[out_offset..required_size]
+                            .copy_from_slice(&return_data[..write_size]);
+                            let active_words = self.memory.len() / 32;      //アクティブなword数を更新
+                            self.active_words = active_words;
+                        }
+                        //Returndata バッファの更新
+                        self.return_back = return_data;
+                        //ガスの精算
+                        self.gas = self.gas + return_gas;
+                        //アクセス済みリストの更新
+                        if !substate.a_access.contains(&to_address) {
+                            substate.a_access.push(to_address.clone())
+                        }
+                        //結果push
+                        self.push(U256::ZERO);
+
+                    },
+
+                    Err((return_gas, None)) => {
+                        //アクセス済みリストの更新
+                        if !substate.a_access.contains(&to_address) {
+                            substate.a_access.push(to_address.clone())
+                        }
+                        //結果push
+                        self.push(U256::ZERO);
+                    },
+                }
+
+
+
             }
 
             0xf3 => {

--- a/src/evm/execution.rs
+++ b/src/evm/execution.rs
@@ -431,8 +431,8 @@ impl Ofunction for EVM {
             0x37 => {
                 //CALLDATACOPY
                 let data = &execution_environment.i_data;
-                let dest_offset = self.pop().try_into().unwrap_or(usize::MAX);
-                let offset = self.pop().try_into().unwrap_or(usize::MAX);
+                let dest_offset = self.pop().try_into().unwrap_or(usize::MAX);  //メモリ
+                let offset = self.pop().try_into().unwrap_or(usize::MAX);   //CALLDATA
                 let size = self.pop().try_into().unwrap_or(usize::MAX);
                 //メモリ拡張
                 if size != 0 {
@@ -442,17 +442,17 @@ impl Ofunction for EVM {
                         self.memory.resize(words * 32, 0);
                     }
                     //メモリに値を書き込む
+                    let mut slice = vec![0u8;size];
                     let read_size = offset.saturating_add(size);
                     if offset <= data.len() {
                         if read_size > data.len() {
                             let copy_len = data.len() - offset;
-                            self.memory[dest_offset..dest_offset + copy_len]
-                                .copy_from_slice(&data[offset..data.len()]);
+                            slice[..copy_len].copy_from_slice(&data[offset..data.len()]);
                         } else {
-                            self.memory[dest_offset..required_size]
-                                .copy_from_slice(&data[offset..read_size]);
+                                slice.copy_from_slice(&data[offset..read_size]);
                         }
                     }
+                    self.memory[dest_offset..required_size].copy_from_slice(&slice);
                 }
                 //アクティブなword数を更新
                 let active_words = self.memory.len() / 32;

--- a/src/evm/gas.rs
+++ b/src/evm/gas.rs
@@ -402,15 +402,7 @@ impl Gfunction for EVM {
                 let base_cost = ext_cost
                     .saturating_add(acc_cost)
                     .saturating_add(create_cost);
-                //サブコールへのガス割当
-                let gr = self.gas.saturating_sub(base_cost);
-                let gr = gr - (gr / U256::from(64));
-                let mut result = if gr > child_gas_limit {
-                    child_gas_limit
-                } else {
-                    gr
-                };
-                return result.saturating_add(base_cost);
+                return base_cost;
             }
 
             0xf2 => {
@@ -447,15 +439,7 @@ impl Gfunction for EVM {
                 let base_cost = ext_cost
                     .saturating_add(acc_cost)
                     .saturating_add(create_cost);
-                //サブコールへのガス割当
-                let gr = self.gas.saturating_sub(base_cost);
-                let gr = gr - (gr / U256::from(64));
-                let mut result = if gr > child_gas_limit {
-                    child_gas_limit
-                } else {
-                    gr
-                };
-                return result.saturating_add(base_cost);
+                return base_cost;
             }
 
             0xf3 | 0xfd => {
@@ -492,15 +476,7 @@ impl Gfunction for EVM {
                 let acc_cost = self.is_account_access(address, substate);
 
                 let base_cost = ext_cost.saturating_add(acc_cost);
-                //サブコールへのガス割当
-                let gr = self.gas.saturating_sub(base_cost);
-                let gr = gr - (gr / U256::from(64));
-                let mut result = if gr > child_gas_limit {
-                    child_gas_limit
-                } else {
-                    gr
-                };
-                return result.saturating_add(base_cost);
+                return base_cost;
             }
 
             0xf5 => {

--- a/src/evm/gas.rs
+++ b/src/evm/gas.rs
@@ -187,7 +187,7 @@ impl Gfunction for EVM {
                         .saturating_mul(U256::from(10))
                         .saturating_add(U256::from(10));
                     result
-                }else{
+                } else {
                     let result = byte_u256
                         .saturating_mul(U256::from(50))
                         .saturating_add(U256::from(10));
@@ -270,14 +270,14 @@ impl Gfunction for EVM {
                 let key = self.peek(0);
                 if self.version == VersionId::Frontier {
                     U256::from(50)
-                }else{
+                } else {
                     let key_case = substate.a_access_storage.get(address);
                     if key_case.is_none() {
                         U256::from(2100)
-                    }else{
+                    } else {
                         if key_case.unwrap().contains_key(&key) {
                             U256::from(100)
-                        }else{
+                        } else {
                             U256::from(2100)
                         }
                     }
@@ -299,32 +299,32 @@ impl Gfunction for EVM {
                     } else {
                         U256::from(5000)
                     }
-                }else{
+                } else {
                     let mut called_cost = 0usize;
                     let key_case = substate.a_access_storage.get(address);
                     let original_value = if key_case.is_none() {
-                        called_cost = 2100;    //called_cost2100を付加
-                        current_value   
-                    }else{
+                        called_cost = 2100; //called_cost2100を付加
+                        current_value
+                    } else {
                         let val1 = key_case.unwrap().get(&key);
                         if val1.is_none() {
-                            called_cost = 2100;    //called_cost2100を付加
+                            called_cost = 2100; //called_cost2100を付加
                             current_value
-                        }else{
+                        } else {
                             val1.unwrap().clone()
                         }
                     };
                     //Update Costを算出
                     let update_cost = if current_value == new_value {
                         100
-                    }else{
-                        if current_value == original_value{
+                    } else {
+                        if current_value == original_value {
                             if original_value == U256::from(0) {
                                 20000
-                            }else{
+                            } else {
                                 2900
                             }
-                        }else{
+                        } else {
                             100
                         }
                     };
@@ -496,27 +496,29 @@ impl Gfunction for EVM {
             0xff => {
                 if self.version == VersionId::Frontier {
                     return U256::ZERO;
-                }else{
+                } else {
                     let data = self.peek(0);
                     //送り先のアドレスのアクセス状態
                     let address = Address::from_u256(data);
                     let access_state_cost = if substate.a_access.contains(&address) {
                         0usize
-                    }else{
+                    } else {
                         2600
                     };
 
                     //新規アカウント作成のペナルティ
                     let my_address = &execution_environment.i_address;
-                    let create_cost = if state.get_balance(my_address).unwrap_or(U256::from(0)) > U256::from(0) && state.is_empty(&address) {
+                    let create_cost = if state.get_balance(my_address).unwrap_or(U256::from(0))
+                        > U256::from(0)
+                        && state.is_empty(&address)
+                    {
                         25000
-                    }else {
+                    } else {
                         0
                     };
                     let total = create_cost + access_state_cost + 5000;
                     return U256::from(total);
                 }
-
             }
 
             _ => U256::from(0),

--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -3,7 +3,7 @@
 use crate::evm::evm::EVM;
 use crate::leviathan::roleback::Action;
 use crate::leviathan::structs::{
-    BackupSubstate, BlockHeader, ExecutionEnvironment, Log, SubState, Transaction, VersionId
+    BackupSubstate, BlockHeader, ExecutionEnvironment, Log, SubState, Transaction, VersionId,
 };
 use crate::leviathan::world_state::{Account, Address, WorldState};
 use crate::my_trait::leviathan_trait::{
@@ -15,7 +15,7 @@ use sha3::{Digest, Keccak256};
 pub struct LEVIATHAN {
     pub journal: Vec<Action>,
     pub substate_backup: BackupSubstate,
-    pub version: VersionId
+    pub version: VersionId,
 }
 
 impl LEVIATHAN {
@@ -23,7 +23,7 @@ impl LEVIATHAN {
         Self {
             journal: Vec::<Action>::new(),
             substate_backup: BackupSubstate::new(),
-            version: version
+            version: version,
         }
     }
 
@@ -181,7 +181,7 @@ mod state_tests {
     use crate::test::state_parser::StateTestSuite;
 
     // --- ヘルパー関数 ---
-    
+
     // 🌟 追加: JSONの "network" 文字列から VersionId を取得する関数
     fn parse_version(network_str: &str) -> VersionId {
         // ">Frontier" や ">=Frontier" などのプレフィックスを削除して純粋なフォーク名にする
@@ -304,8 +304,9 @@ mod state_tests {
     }
 
     #[test]
-    fn test_add11_state_strict() {
-        let test_file = "testdata/GeneralStateTestsFiller/stMemoryTest/callDataCopyOffsetFiller.json";
+    fn state_test() {
+        let test_file =
+            "testdata/GeneralStateTestsFiller/stMemoryTest/callDataCopyOffsetFiller.json";
         let json_data = fs::read_to_string(test_file).expect("Failed to read JSON file");
 
         let mut raw_json: serde_json::Value =
@@ -407,7 +408,7 @@ mod state_tests {
 
             //  修正: LEVIATHAN::new() にバージョンを渡す
             let mut leviathan = LEVIATHAN::new(version);
-            
+
             let result = leviathan.execution(&mut state, transaction, &block_header);
 
             assert!(


### PR DESCRIPTION
## 概要（What）
StateTestを進める過程で発生したエラーを解消するため、以下の2点の作業を行った。
1. 未実装であった `CALL` オペコードの追加
2. 既存の `CALLDATACOPY` オペコードの挙動修正（ゼロ埋め処理）

これにより、`GeneralStateTestsFiller/stMemoryTest/callDataCopyOffsetFiller.json` のテストをパスした。

## 背景・開発の流れ（Why）
当初、StateTest実行時に `CALL` オペコードが未定義によりエラーとなったため、本ブランチ (`feat/...-AddOpecode`) を作成し実装を行った。
しかし、`CALL` 実装後もテストが通らず調査を進めた結果、以前実装した `CALLDATACOPY` の挙動に**イエローペーパーの仕様と異なる部分があること（潜在的なバグ）が発覚した**ため、併せて修正を行った。

## 詳細な修正内容（How）

### 1. CALL オペコードの実装
`CALL` はトランザクション実行構造体（LEVIATHAN）の `message_call` メソッドを用いて実装した。
サブコールが失敗した場合はロールバックし、成功した場合は子LEVIATHANのActionジャーナルを親LEVIATHANのジャーナルにappendする設計とした。これにより、親の実行が最終的に失敗した場合でも、子LEVIATHANが行ったSTATEの変化を正確にロールバックすることが可能となった。

### 2. CALLDATACOPY の仕様準拠とクラッシュ対策
**[エラー原因]**
テスト内では calldata サイズよりも大きな offset を指定し、意図的にメモリ上に存在していたデータを0で上書きするコードが記述されていた。修正前のコードでは、データ長よりも大きな offset が与えられた場合、未処理のまま済ませていたためテストに失敗していた。

**[仕様の根拠]**
イエローペーパーにおいては「コールデータは無限の大きさを持ち、データ長を超える範囲は0で埋まっている」と定義されている。

**[安全な解決方法（セキュリティ配慮）]**
仕様通りに `offset + size` まで巨大な0の配列で確保した場合、悪意ある長大な offset 指定によってメモリを枯渇させ、ノードのクラッシュ（DoS）を引き起こす危険性があった。
そこで、以下の安全なアプローチを採用した：
* あらかじめ `size` 長の0で初期化された `Vec` を作成。
* そこに実際の `calldata` を流し込む（offset位置とコピー範囲で場合分けを行う）。
* この完成した `Vec` をメモリに書き込む。
これにより、イエローペーパーの仕様を安全に満たしつつ、テストをパスすることに成功した。