### PR TITLE
Fix/st memoryfix(test): 実行エラー(Err)時にテストランナーがパニックする不具合を修正 test dejavu

### DIFF
--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -306,7 +306,7 @@ mod state_tests {
     #[test]
     fn state_test() {
         let test_file =
-            "testdata/GeneralStateTestsFiller/stMemoryTest/callDataCopyOffsetFiller.json";
+            "testdata/GeneralStateTestsFiller/stMemoryTest/calldatacopy_dejavuFiller.json";
         let json_data = fs::read_to_string(test_file).expect("Failed to read JSON file");
 
         let mut raw_json: serde_json::Value =
@@ -410,12 +410,11 @@ mod state_tests {
             let mut leviathan = LEVIATHAN::new(version);
 
             let result = leviathan.execution(&mut state, transaction, &block_header);
-
-            assert!(
-                result.is_ok(),
-                "Transaction execution failed: {:?}",
-                result.err()
-            );
+            
+            match result {
+                Ok(_) => println!("  => Transaction Result: Success"),
+                Err(_) => println!("  => Transaction Result: Exception Halt (Expected)"),
+            }
 
             let expect_data = &test_data.expect[0];
             for (addr_str, expected_acc) in &expect_data.result {

--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -410,7 +410,7 @@ mod state_tests {
             let mut leviathan = LEVIATHAN::new(version);
 
             let result = leviathan.execution(&mut state, transaction, &block_header);
-            
+
             match result {
                 Ok(_) => println!("  => Transaction Result: Success"),
                 Err(_) => println!("  => Transaction Result: Exception Halt (Expected)"),


### PR DESCRIPTION
## 概要（What）
StateTestのテストランナーにおいて、`leviathan.execution` が `Err` を返した際にパニックを起こしてテストが強制終了してしまう不具合を修正した。
これにより、意図的にエラーを発生させる異常系テスト（不正なオペコードやリソース不足など）を正しく評価できるようになった。

## 背景・課題（Why）
EVMの公式StateTestには、トランザクションが失敗した際の状態遷移（ロールバック等）が正しく行われるかを検証するテストケースが多数存在する。
しかし、以前の実装では `assert!` を用いていたため、`Err` 時にテスト全体が停止していた。これを `match` によるハンドリングに変更し、実行結果に関わらず状態検証へ進むよう修正した。

## 詳細な修正内容と設計根拠（How & Rationale）

### 1. 制御フローの修正
テストランナーにおける `leviathan.execution` の戻り値の処理を見直し、パニックを取り除いた。実行結果が `Ok` の場合だけでなく、`Err`（実行失敗）が返却された場合においても、その時点での State（状態）の遷移および最終的なハッシュ値の検証プロセスへ正しく移行するように修正を行った。

### 2. イエローペーパーの仕様への準拠
`leviathan.execution` が `Result` 型を返す設計は、イエローペーパーにおける **$\Upsilon$（ウプシロン）関数** の戻り値の定義（ステータスコードの返却）に忠実に沿ったものである。

### 3. 状態遷移のハンドリング
本実装において状態（State）が戻り値に含まれていないのは、実行関数に対して `&mut State`（可変参照）を渡し、関数内部で直接状態を更新する仕様を採用しているためである。
今回の修正により、たとえ実行自体が `Err`（例外終了）となった場合でも、その過程で `&mut` を通じて行われた状態の変化（あるいは適切に処理されたロールバック結果）を、テストランナーが正しく検証することが可能となった。