### PR TITLE
refactor(state): State操作メソッドの責務分離と送金時の安全検証強化

### DIFF
--- a/src/evm/execution.rs
+++ b/src/evm/execution.rs
@@ -1112,6 +1112,9 @@ impl Ofunction for EVM {
                     state.reset_balance(from_address)
                 } else {
                     if balance != U256::ZERO {
+                        if state.is_empty(&from_address) {
+                            return Some(false);
+                        }
                         if state.is_empty(&to_address) {
                             state.add_account(&to_address, Account::new());   //アカウントを追加
                             Action::Account_creation(to_address.clone()).push(leviathan, state); //アカウントが存在しない場合

--- a/src/evm/execution.rs
+++ b/src/evm/execution.rs
@@ -1112,6 +1112,10 @@ impl Ofunction for EVM {
                     state.reset_balance(from_address)
                 } else {
                     if balance != U256::ZERO {
+                        if state.is_empty(&to_address) {
+                            state.add_account(&to_address, Account::new());   //アカウントを追加
+                            Action::Account_creation(to_address.clone()).push(leviathan, state); //アカウントが存在しない場合
+                        }
                         Action::Send_eth(from_address.clone(), to_address.clone(), balance)
                             .push(leviathan, state); //ロールバック用
                         state.send_eth(from_address, &to_address, balance);

--- a/src/evm/execution.rs
+++ b/src/evm/execution.rs
@@ -1116,7 +1116,7 @@ impl Ofunction for EVM {
                             return Some(false);
                         }
                         if state.is_empty(&to_address) {
-                            state.add_account(&to_address, Account::new());   //アカウントを追加
+                            state.add_account(&to_address, Account::new()); //アカウントを追加
                             Action::Account_creation(to_address.clone()).push(leviathan, state); //アカウントが存在しない場合
                         }
                         Action::Send_eth(from_address.clone(), to_address.clone(), balance)

--- a/src/leviathan/call.rs
+++ b/src/leviathan/call.rs
@@ -49,6 +49,7 @@ impl MessageCall for LEVIATHAN {
         //残高の移動
         if eth != U256::ZERO {
             if state.is_empty(&recipient) {
+                state.add_account(&recipient, Account::new());   //アカウントを追加
                 Action::Account_creation(recipient.clone()).push(self, state); //アカウントが存在しない場合
             }
             if sender != recipient {

--- a/src/leviathan/call.rs
+++ b/src/leviathan/call.rs
@@ -52,7 +52,7 @@ impl MessageCall for LEVIATHAN {
                 return Err((U256::ZERO, None, None));
             }
             if state.is_empty(&recipient) {
-                state.add_account(&recipient, Account::new());   //アカウントを追加
+                state.add_account(&recipient, Account::new()); //アカウントを追加
                 Action::Account_creation(recipient.clone()).push(self, state); //アカウントが存在しない場合
             }
             if sender != recipient {

--- a/src/leviathan/call.rs
+++ b/src/leviathan/call.rs
@@ -48,6 +48,9 @@ impl MessageCall for LEVIATHAN {
 
         //残高の移動
         if eth != U256::ZERO {
+            if state.is_empty(&sender) {
+                return Err((U256::ZERO, None, None));
+            }
             if state.is_empty(&recipient) {
                 state.add_account(&recipient, Account::new());   //アカウントを追加
                 Action::Account_creation(recipient.clone()).push(self, state); //アカウントが存在しない場合

--- a/src/leviathan/create.rs
+++ b/src/leviathan/create.rs
@@ -90,6 +90,9 @@ impl ContractCreation for LEVIATHAN {
             state.inc_nonce(&contract_address);
         }
         //送金する
+        if state.is_empty(&sender) {
+            return Err((U256::ZERO, None, None));
+        }
         if state.is_empty(&contract_address) {
             state.add_account(&contract_address, Account::new());   //アカウントを追加
             Action::Account_creation(contract_address.clone()).push(self, state); //アカウントが存在しない場合

--- a/src/leviathan/create.rs
+++ b/src/leviathan/create.rs
@@ -4,7 +4,7 @@ use crate::evm::evm::EVM;
 use crate::leviathan::leviathan::LEVIATHAN;
 use crate::leviathan::roleback::Action;
 use crate::leviathan::structs::{
-    BackupSubstate, BlockHeader, ExecutionEnvironment, Log, SubState, Transaction,
+    BackupSubstate, BlockHeader, ExecutionEnvironment, Log, SubState, Transaction, VersionId
 };
 use crate::leviathan::world_state::{Account, Address, WorldState};
 use crate::my_trait::evm_trait::{Gfunction, Hfunction, Ofunction, Xi, Zfunction};
@@ -82,10 +82,13 @@ impl ContractCreation for LEVIATHAN {
 
         //Nonceを1にする．
         if state.is_empty(&contract_address) {
+            state.add_account(&contract_address, Account::new());   //アカウントを追加
             Action::Account_creation(contract_address.clone()).push(self, state); //アカウントが存在しない場合
         }
         Action::Add_nonce(contract_address.clone()).push(self, state); //ロールバック用
-        state.inc_nonce(&contract_address);
+        if self.version >= VersionId::SpuriousDragon {
+            state.inc_nonce(&contract_address);
+        }
         //送金する
         Action::Send_eth(sender.clone(), contract_address.clone(), eth).push(self, state); //ロールバック用
         state.send_eth(&sender, &contract_address, eth);

--- a/src/leviathan/create.rs
+++ b/src/leviathan/create.rs
@@ -90,6 +90,10 @@ impl ContractCreation for LEVIATHAN {
             state.inc_nonce(&contract_address);
         }
         //送金する
+        if state.is_empty(&contract_address) {
+            state.add_account(&contract_address, Account::new());   //アカウントを追加
+            Action::Account_creation(contract_address.clone()).push(self, state); //アカウントが存在しない場合
+        }
         Action::Send_eth(sender.clone(), contract_address.clone(), eth).push(self, state); //ロールバック用
         state.send_eth(&sender, &contract_address, eth);
         //storageRootを空にする

--- a/src/leviathan/create.rs
+++ b/src/leviathan/create.rs
@@ -4,7 +4,7 @@ use crate::evm::evm::EVM;
 use crate::leviathan::leviathan::LEVIATHAN;
 use crate::leviathan::roleback::Action;
 use crate::leviathan::structs::{
-    BackupSubstate, BlockHeader, ExecutionEnvironment, Log, SubState, Transaction, VersionId
+    BackupSubstate, BlockHeader, ExecutionEnvironment, Log, SubState, Transaction, VersionId,
 };
 use crate::leviathan::world_state::{Account, Address, WorldState};
 use crate::my_trait::evm_trait::{Gfunction, Hfunction, Ofunction, Xi, Zfunction};
@@ -82,7 +82,7 @@ impl ContractCreation for LEVIATHAN {
 
         //Nonceを1にする．
         if state.is_empty(&contract_address) {
-            state.add_account(&contract_address, Account::new());   //アカウントを追加
+            state.add_account(&contract_address, Account::new()); //アカウントを追加
             Action::Account_creation(contract_address.clone()).push(self, state); //アカウントが存在しない場合
         }
         Action::Add_nonce(contract_address.clone()).push(self, state); //ロールバック用
@@ -94,7 +94,7 @@ impl ContractCreation for LEVIATHAN {
             return Err((U256::ZERO, None, None));
         }
         if state.is_empty(&contract_address) {
-            state.add_account(&contract_address, Account::new());   //アカウントを追加
+            state.add_account(&contract_address, Account::new()); //アカウントを追加
             Action::Account_creation(contract_address.clone()).push(self, state); //アカウントが存在しない場合
         }
         Action::Send_eth(sender.clone(), contract_address.clone(), eth).push(self, state); //ロールバック用

--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -99,7 +99,7 @@ impl TransactionExecution for LEVIATHAN {
         //=======ステップ2===========
         //【Nonceの加算】
         if state.is_empty(&sender_address) {
-            return Err((U256::ZERO, Vec::new())) //sender_addressが見つからないのは異常
+            return Err((U256::ZERO, Vec::new())); //sender_addressが見つからないのは異常
         }
         state.inc_nonce(&sender_address);
         //【前払いガス代の徴収】
@@ -161,8 +161,9 @@ impl TransactionExecution for LEVIATHAN {
                 let return_gas = gas.saturating_add(reimburse);
                 //送信者への返金
                 let reimburse = return_gas.saturating_mul(transaction.t_price);
-                if state.is_empty(&sender_address) {      //set_balance前の確認
-                    state.add_account(&sender_address, Account::new());   //アカウントを追加
+                if state.is_empty(&sender_address) {
+                    //set_balance前の確認
+                    state.add_account(&sender_address, Account::new()); //アカウントを追加
                     Action::Account_creation(sender_address.clone()).push(self, state); //アカウントが存在しない場合
                 }
                 state.set_balance(&sender_address, reimburse);
@@ -170,8 +171,9 @@ impl TransactionExecution for LEVIATHAN {
                 let final_billed_gas = transaction.t_gas_limit.saturating_sub(return_gas);
                 let f = transaction.t_price - block_header.h_basefee;
                 let reward = final_billed_gas.saturating_mul(f);
-                if state.is_empty(&block_header.h_beneficiary) {      //set_balance前の確認
-                    state.add_account(&block_header.h_beneficiary, Account::new());   //アカウントを追加
+                if state.is_empty(&block_header.h_beneficiary) {
+                    //set_balance前の確認
+                    state.add_account(&block_header.h_beneficiary, Account::new()); //アカウントを追加
                     Action::Account_creation(block_header.h_beneficiary.clone()).push(self, state); //アカウントが存在しない場合
                 }
                 state.set_balance(&block_header.h_beneficiary, reward);
@@ -180,8 +182,9 @@ impl TransactionExecution for LEVIATHAN {
             Err((gas, _, _)) => {
                 //送信者への返金
                 let reimburse = gas.saturating_mul(transaction.t_price);
-                if state.is_empty(&sender_address) {      //set_balance前の確認
-                    state.add_account(&sender_address, Account::new());   //アカウントを追加
+                if state.is_empty(&sender_address) {
+                    //set_balance前の確認
+                    state.add_account(&sender_address, Account::new()); //アカウントを追加
                     Action::Account_creation(sender_address.clone()).push(self, state); //アカウントが存在しない場合
                 }
                 state.set_balance(&sender_address, reimburse);
@@ -189,8 +192,9 @@ impl TransactionExecution for LEVIATHAN {
                 let final_billed_gas = transaction.t_gas_limit.saturating_sub(gas);
                 let f = transaction.t_price - block_header.h_basefee;
                 let reward = final_billed_gas.saturating_mul(f);
-                if state.is_empty(&block_header.h_beneficiary) {      //set_balance前の確認
-                    state.add_account(&block_header.h_beneficiary, Account::new());   //アカウントを追加
+                if state.is_empty(&block_header.h_beneficiary) {
+                    //set_balance前の確認
+                    state.add_account(&block_header.h_beneficiary, Account::new()); //アカウントを追加
                     Action::Account_creation(block_header.h_beneficiary.clone()).push(self, state); //アカウントが存在しない場合
                 }
                 state.set_balance(&block_header.h_beneficiary, reward);

--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -98,6 +98,9 @@ impl TransactionExecution for LEVIATHAN {
 
         //=======ステップ2===========
         //【Nonceの加算】
+        if state.is_empty(&sender_address) {
+            return Err((U256::ZERO, Vec::new())) //sender_addressが見つからないのは異常
+        }
         state.inc_nonce(&sender_address);
         //【前払いガス代の徴収】
         let gas = state.buy_gas(
@@ -158,6 +161,10 @@ impl TransactionExecution for LEVIATHAN {
                 let return_gas = gas.saturating_add(reimburse);
                 //送信者への返金
                 let reimburse = return_gas.saturating_mul(transaction.t_price);
+                if state.is_empty(&sender_address) {      //set_balance前の確認
+                    state.add_account(&sender_address, Account::new());   //アカウントを追加
+                    Action::Account_creation(sender_address.clone()).push(self, state); //アカウントが存在しない場合
+                }
                 state.set_balance(&sender_address, reimburse);
                 //マイナーへの支払い
                 let final_billed_gas = transaction.t_gas_limit.saturating_sub(return_gas);

--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -170,17 +170,29 @@ impl TransactionExecution for LEVIATHAN {
                 let final_billed_gas = transaction.t_gas_limit.saturating_sub(return_gas);
                 let f = transaction.t_price - block_header.h_basefee;
                 let reward = final_billed_gas.saturating_mul(f);
+                if state.is_empty(&block_header.h_beneficiary) {      //set_balance前の確認
+                    state.add_account(&block_header.h_beneficiary, Account::new());   //アカウントを追加
+                    Action::Account_creation(block_header.h_beneficiary.clone()).push(self, state); //アカウントが存在しない場合
+                }
                 state.set_balance(&block_header.h_beneficiary, reward);
                 return Ok((final_billed_gas, substate.a_log.clone()));
             }
             Err((gas, _, _)) => {
                 //送信者への返金
                 let reimburse = gas.saturating_mul(transaction.t_price);
+                if state.is_empty(&sender_address) {      //set_balance前の確認
+                    state.add_account(&sender_address, Account::new());   //アカウントを追加
+                    Action::Account_creation(sender_address.clone()).push(self, state); //アカウントが存在しない場合
+                }
                 state.set_balance(&sender_address, reimburse);
                 //マイナーへの支払い
                 let final_billed_gas = transaction.t_gas_limit.saturating_sub(gas);
                 let f = transaction.t_price - block_header.h_basefee;
                 let reward = final_billed_gas.saturating_mul(f);
+                if state.is_empty(&block_header.h_beneficiary) {      //set_balance前の確認
+                    state.add_account(&block_header.h_beneficiary, Account::new());   //アカウントを追加
+                    Action::Account_creation(block_header.h_beneficiary.clone()).push(self, state); //アカウントが存在しない場合
+                }
                 state.set_balance(&block_header.h_beneficiary, reward);
                 return Err((final_billed_gas, Vec::new()));
             }

--- a/src/leviathan/state_method.rs
+++ b/src/leviathan/state_method.rs
@@ -76,13 +76,8 @@ impl State for WorldState {
     }
 
     fn dec_nonce(&mut self, address: &Address) {
-        let account = self.0.get_mut(&address);
-        match account {
-            Some(x) => {
-                x.nonce -= 1;
-            }
-            None => (),
-        }
+        let account = self.0.get_mut(&address).expect("[dec_nonce]: アカウントが存在しない");
+        account.nonce += 1
     }
 
     fn set_storage(&mut self, address: &Address, key: U256, value: U256) {
@@ -101,24 +96,14 @@ impl State for WorldState {
     }
 
     fn send_eth(&mut self, from: &Address, to: &Address, eth: U256) -> Result<(), &'static str> {
-        let mut from_account = self
-            .0
-            .get_mut(from)
-            .ok_or("送信元のアカウントが存在しない")?;
+        let from_account = self.0.get_mut(from).expect("[dec_nonce]: アカウントが存在しない");
         if from_account.balance >= eth {
             from_account.balance -= eth;
         } else {
             return Err("残高不足");
         }
-        let to_account = self.0.get_mut(to);
-        if to_account.is_none() {
-            //アカウントを作成
-            self.0.insert(to.clone(), Account::new());
-            let mut new_account = self.0.get_mut(to).unwrap();
-            new_account.balance += eth;
-        } else {
-            to_account.unwrap().balance += eth;
-        }
+        let to_account = self.0.get_mut(to).expect("[dec_nonce]: アカウントが存在しない");
+        to_account.balance += eth;
         return Ok(());
     }
 

--- a/src/leviathan/state_method.rs
+++ b/src/leviathan/state_method.rs
@@ -64,33 +64,15 @@ impl State for WorldState {
     }
 
     fn set_balance(&mut self, address: &Address, value: U256) {
-        let account = self.0.get_mut(&address);
-        match account {
-            Some(x) => {
-                x.balance += value;
-            }
-            None => {
-                //アカウントを作成
-                self.0.insert(address.clone(), Account::new());
-                let account = self.0.get_mut(&address).unwrap();
-                account.balance = value;
-            }
-        }
+        let account = self.0.get_mut(&address).expect("アカウントが存在しない.事前にadd_account");
+        account.balance += value;
     }
 
     fn inc_nonce(&mut self, address: &Address) {
-        let account = self.0.get_mut(&address);
-        match account {
-            Some(x) => {
-                x.nonce += 1;
-            }
-            None => {
-                //アカウントを作成
-                self.0.insert(address.clone(), Account::new());
-                let account = self.0.get_mut(&address).unwrap();
-                account.nonce = 1;
-            }
-        }
+        //エラーが出るはずがない
+        //事前にチェックして，&mut self系は呼ぶ
+        let account = self.0.get_mut(&address).expect("アカウントが存在しない.事前にadd_account");
+        account.nonce += 1
     }
 
     fn dec_nonce(&mut self, address: &Address) {

--- a/src/leviathan/state_method.rs
+++ b/src/leviathan/state_method.rs
@@ -64,19 +64,28 @@ impl State for WorldState {
     }
 
     fn set_balance(&mut self, address: &Address, value: U256) {
-        let account = self.0.get_mut(&address).expect("アカウントが存在しない.事前にadd_account");
+        let account = self
+            .0
+            .get_mut(&address)
+            .expect("アカウントが存在しない.事前にadd_account");
         account.balance += value;
     }
 
     fn inc_nonce(&mut self, address: &Address) {
         //エラーが出るはずがない
         //事前にチェックして，&mut self系は呼ぶ
-        let account = self.0.get_mut(&address).expect("アカウントが存在しない.事前にadd_account");
+        let account = self
+            .0
+            .get_mut(&address)
+            .expect("アカウントが存在しない.事前にadd_account");
         account.nonce += 1
     }
 
     fn dec_nonce(&mut self, address: &Address) {
-        let account = self.0.get_mut(&address).expect("[dec_nonce]: アカウントが存在しない");
+        let account = self
+            .0
+            .get_mut(&address)
+            .expect("[dec_nonce]: アカウントが存在しない");
         account.nonce += 1
     }
 
@@ -96,13 +105,19 @@ impl State for WorldState {
     }
 
     fn send_eth(&mut self, from: &Address, to: &Address, eth: U256) -> Result<(), &'static str> {
-        let from_account = self.0.get_mut(from).expect("[dec_nonce]: アカウントが存在しない");
+        let from_account = self
+            .0
+            .get_mut(from)
+            .expect("[dec_nonce]: アカウントが存在しない");
         if from_account.balance >= eth {
             from_account.balance -= eth;
         } else {
             return Err("残高不足");
         }
-        let to_account = self.0.get_mut(to).expect("[dec_nonce]: アカウントが存在しない");
+        let to_account = self
+            .0
+            .get_mut(to)
+            .expect("[dec_nonce]: アカウントが存在しない");
         to_account.balance += eth;
         return Ok(());
     }


### PR DESCRIPTION
## 概要（What）
Stateを操作するコアメソッド（`inc_nonce`、`set_balance`、`send_eth`）から「暗黙的なアカウント追加機能」を削除し、メソッドの責務をシンプルにするリファクタリングを行った。
また、送金（`send_eth`）処理におけるアカウントの存在検証ロジックを強化し、EVMの実行コンテキストに応じた適切なエラーハンドリングを実装した。

## 背景・課題（Why）
以前の実装では、State更新メソッド内部でアカウントが存在しない場合に自動で作成する処理が含まれていた。しかし、この設計には以下の課題があった。
* **トランザクションのロールバック:** ジャーナルを利用してStateの変更を取り消す際、内部で暗黙的に作成されたアカウントのトラッキングが複雑になり、致命的なバグを引き起こすリスクがあった。
* **拡張性と保守性:** 各メソッドが複数の責務を持つことになり、将来的な拡張の妨げとなっていた。

## 詳細な修正内容（How）

### 1. アカウント追加ロジックの分離（inc_nonce / set_balance）
* `inc_nonce` および `set_balance` の内部からアカウント作成処理を削除した。
* 呼び出し側で事前にアカウントの存在確認を行い、存在しない場合のみ明示的にアカウントを追加してからこれらのメソッドを実行するよう制御フローを修正した（修正漏れ箇所も網羅的に対応済）。

### 2. 送金処理（send_eth）の受信者チェック修正
* `send_eth` 内部のアカウント追加機能を削除した。
* 送金実行前に、送金先（受信者）のアカウントが存在するかを確認し、存在しない場合は作成してから送金処理へ移行するよう修正した。

### 3. 送金処理（send_eth）の送信者に対する厳密な安全検証
送信者（Sender）は仕様上必ず存在する前提ではあるが、システムの安全性を担保するため、送信者の存在確認を必須とするよう防衛的実装を追加した。コンテキストにより以下の通り挙動を分岐させている。
* **MessageCall / ContractCreation 実行時:** 送信者が存在しないという異常事態が発生した場合は、`Err(U256::ZERO, None, None)` を返し、例外停止（Exception Halt）させる。
* **SELFDESTRUCT 実行時:** 仕様に則り、正常停止するようにハンドリングした。