### PR TITLE
refactor(core): CALL系例外時のガス処理修正およびSSTOREの2300ガスストッパーのフォーク対応

### DIFF
--- a/src/evm/execution.rs
+++ b/src/evm/execution.rs
@@ -409,8 +409,6 @@ impl Ofunction for EVM {
             }
 
             Err((return_gas, None, _)) => {
-                //ガスの精算
-                self.gas = self.gas + return_gas;
                 //アクセス済みリストの更新
                 if !substate.a_access.contains(&to_address) {
                     substate.a_access.push(to_address.clone())
@@ -1533,7 +1531,6 @@ impl Ofunction for EVM {
             Err((return_gas, None, _)) => {
                 tracing::info!("CREATE: 例外停止");
                 //ガスの精算
-                self.gas = self.gas + return_gas;
                 self.push(U256::ZERO);
             }
             Ok((_, _, None)) => todo!(),
@@ -1656,7 +1653,6 @@ impl Ofunction for EVM {
             Err((return_gas, None, _)) => {
                 tracing::info!("CREATE2: 例外停止");
                 //ガスの精算
-                self.gas = self.gas + return_gas;
                 self.push(U256::ZERO);
             }
             Ok((_, _, None)) => todo!(),
@@ -1809,8 +1805,6 @@ impl Ofunction for EVM {
             }
 
             Err((return_gas, None, _)) => {
-                //ガスの精算
-                self.gas = self.gas + return_gas;
                 //アクセス済みリストの更新
                 if !substate.a_access.contains(&to_address) {
                     substate.a_access.push(to_address.clone())
@@ -1954,8 +1948,6 @@ impl Ofunction for EVM {
             }
 
             Err((return_gas, None, _)) => {
-                //ガスの精算
-                self.gas = self.gas + return_gas;
                 //アクセス済みリストの更新
                 if !substate.a_access.contains(&to_address) {
                     substate.a_access.push(to_address.clone())
@@ -2100,8 +2092,6 @@ impl Ofunction for EVM {
             }
 
             Err((return_gas, None, _)) => {
-                //ガスの精算
-                self.gas = self.gas + return_gas;
                 //アクセス済みリストの更新
                 if !substate.a_access.contains(&to_address) {
                     substate.a_access.push(to_address.clone())

--- a/src/evm/safe.rs
+++ b/src/evm/safe.rs
@@ -181,7 +181,7 @@ impl Zfunction for EVM {
         //命令のガスコストと現在の残ガスを比較
         let gas_cost = self.gas(opcode, substate, state, execution_environment);
         if self.gas < gas_cost {
-            tracing::warn!("残ガスが足りない");
+            tracing::warn!("[is_safe]残ガスが足りない");
             return false;
         }
 
@@ -206,9 +206,11 @@ impl Zfunction for EVM {
         }
 
         //命令がSSTOREで残ガスが2300以下
-        if opcode == 0x55 && self.gas <= U256::from(2300) {
-            tracing::warn!("SSTOREを実行するのにガスが2300以下");
-            return false;
+        if self.version >= VersionId::Istanbul {
+            if opcode == 0x55 && self.gas <= U256::from(2300) {
+                tracing::warn!("SSTOREを実行するのにガスが2300以下");
+                return false;
+            }
         }
 
         //RETURNDATACOPYに関するルール

--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -392,7 +392,7 @@ mod state_tests {
             .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
             .try_init();
         // ここにテストしたいディレクトリへのパスを指定します
-        let test_dir = "require/stCreate2";
+        let test_dir = "require/stInitCodeTest";
         //let test_dir = "testdata/GeneralStateTestsFiller/CompleteTest";
 
         let paths = fs::read_dir(test_dir)

--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -192,7 +192,10 @@ impl TransactionExecution for LEVIATHAN {
                 }
                 state.set_balance(&sender_address, reimburse);
                 //マイナーへの支払い
-                tracing::info!("マイナーアドレス: 0x{}",hex::encode(block_header.h_beneficiary.0)); //アドレス
+                tracing::info!(
+                    "マイナーアドレス: 0x{}",
+                    hex::encode(block_header.h_beneficiary.0)
+                ); //アドレス
                 let final_billed_gas = transaction.t_gas_limit.saturating_sub(return_gas);
                 let f = if self.version < VersionId::London {
                     transaction.t_price
@@ -224,7 +227,10 @@ impl TransactionExecution for LEVIATHAN {
                 }
                 state.set_balance(&sender_address, reimburse);
                 //マイナーへの支払い
-                tracing::info!("マイナーアドレス: 0x{}",hex::encode(block_header.h_beneficiary.0)); //アドレス
+                tracing::info!(
+                    "マイナーアドレス: 0x{}",
+                    hex::encode(block_header.h_beneficiary.0)
+                ); //アドレス
                 let final_billed_gas = transaction.t_gas_limit.saturating_sub(gas);
                 let f = if self.version < VersionId::London {
                     transaction.t_price

--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -192,7 +192,7 @@ impl TransactionExecution for LEVIATHAN {
                 }
                 state.set_balance(&sender_address, reimburse);
                 //マイナーへの支払い
-                //println!("マイナーアドレス: 0x{}",hex::encode(block_header.h_beneficiary.0)); //アドレス
+                tracing::info!("マイナーアドレス: 0x{}",hex::encode(block_header.h_beneficiary.0)); //アドレス
                 let final_billed_gas = transaction.t_gas_limit.saturating_sub(return_gas);
                 let f = if self.version < VersionId::London {
                     transaction.t_price
@@ -224,6 +224,7 @@ impl TransactionExecution for LEVIATHAN {
                 }
                 state.set_balance(&sender_address, reimburse);
                 //マイナーへの支払い
+                tracing::info!("マイナーアドレス: 0x{}",hex::encode(block_header.h_beneficiary.0)); //アドレス
                 let final_billed_gas = transaction.t_gas_limit.saturating_sub(gas);
                 let f = if self.version < VersionId::London {
                     transaction.t_price
@@ -392,7 +393,8 @@ mod state_tests {
             .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
             .try_init();
         // ここにテストしたいディレクトリへのパスを指定します
-        let test_dir = "require/stInitCodeTest";
+        let test_dir = "require/stCallCodes";
+        //let test_dir = "require/stCreate2";
         //let test_dir = "testdata/GeneralStateTestsFiller/CompleteTest";
 
         let paths = fs::read_dir(test_dir)


### PR DESCRIPTION
## 概要（What）
`test/stCallCodes` のテストパスに向けて、EVMの `execution` における `CALL` 系オペコードの例外停止時の処理を修正した。また、事前検証（Z関数）において、`SSTORE` 実行時に残ガスが2300以下の場合に例外とする「2300ガスストッパー」を、フォークバージョンに応じて適切に作動するように実装した。

## 背景・課題（Why）
1. **CALL系の例外停止時のガス処理:**
   これまでの実装では、`CALL` 系オペコードが例外停止（Exceptional Halt）を起こした際にも、正常終了時と同様にガスの精算（返却等）を行うロジックが残っていた。Yellow Paperの仕様では、例外停止時は子コンテキストに渡されたガスは全て没収（消費）されるため、この不要な精算処理を削除する必要があった。
2. **SSTOREの2300ガスストッパー:**
   Ethereumの特定のハードフォーク以降、リエントランシー攻撃の防止やCall Stipend（送金時に自動付与される2300ガス）内での状態変更を防ぐため、「残ガスが2300以下の場合は `SSTORE` を実行できず例外とする」ルールが追加されている。これを事前チェックであるZ関数に組み込み、フォークの歴史と整合性を取る必要があった。

## 詳細な修正内容（How）

### 1. CALL系オペコードの例外停止処理の修正
* `EVM.execution` 内の `CALL` 系処理において、実行結果が「例外停止」だった場合に作動していた誤ったガス精算処理を削除した。これにより、例外発生時は子に渡したガスが仕様通り全損扱いとなる。

### 2. Z関数（事前検証）のフォーク対応
* `SSTORE` オペコードに対する実行前検証（Z関数）を拡張した。
* 実行中のフォークバージョンを判定し、該当するフォーク（Istanbul等以降の仕様）において、残ガスが2300以下の状態で `SSTORE` を試みた場合に `Out of Gas` 等の例外として正しく弾くロジックを実装した。

### 3. コードフォーマット
* `cargo fmt` を実行し、コードベース全体のスタイリングを統一した。

## テスト結果
* ローカルでのテスト実行において、これらの修正により `stCallCodes` 等の該当テストの挙動が公式のState Test仕様と合致することを確認。