### PR TITLE
eat(core): Spurious DragonにおけるDEADアカウント概念の実装および旧仕様のCALL・ロールバック挙動の修正

### DIFF
--- a/src/evm/execution.rs
+++ b/src/evm/execution.rs
@@ -247,8 +247,10 @@ impl Ofunction for EVM {
                             return Some(false);
                         }
                         if state.is_empty(&to_address) {
-                            state.add_account(&to_address, Account::new()); //アカウントを追加
-                            Action::Account_creation(to_address.clone()).push(leviathan, state); //アカウントが存在しない場合
+                            if !state.is_physically_exist(&to_address) {
+                                state.add_account(&to_address, Account::new()); //アカウントを追加
+                                Action::Account_creation(to_address.clone()).push(leviathan, state); //アカウントが存在しない場合
+                            }
                         }
                         Action::Send_eth(from_address.clone(), to_address.clone(), balance)
                             .push(leviathan, state); //ロールバック用

--- a/src/evm/gas.rs
+++ b/src/evm/gas.rs
@@ -449,7 +449,7 @@ impl Gfunction for EVM {
                     if !value.is_zero() {
                         create_cost = create_cost.saturating_add(U256::from(9000));
                     }
-                    if state.is_empty(&address) {
+                    if state.is_dead(self.version, &address) {
                         create_cost = create_cost.saturating_add(U256::from(25000));
                     }
                 } else {

--- a/src/evm/gas.rs
+++ b/src/evm/gas.rs
@@ -455,7 +455,7 @@ impl Gfunction for EVM {
                 } else {
                     if !value.is_zero() {
                         create_cost = create_cost.saturating_add(U256::from(9000));
-                        if state.is_empty(&address) {
+                        if state.is_dead(self.version, &address) {
                             create_cost = create_cost.saturating_add(U256::from(25000));
                         }
                     }

--- a/src/evm/safe.rs
+++ b/src/evm/safe.rs
@@ -162,6 +162,10 @@ impl Zfunction for EVM {
             tracing::warn!("不正な命令の実行: フォーク依存的0xf5");
             return false;
         }
+        if self.version < VersionId::SpuriousDragon && opcode == 0xfd {
+            tracing::warn!("不正な命令の実行: フォーク依存的0xfd");
+            return false;
+        }
 
         //現在の命令が要求する要素数に対して，スタックの中身は足りるか？
         let pop_number = op_info[0] as usize;

--- a/src/leviathan/call.rs
+++ b/src/leviathan/call.rs
@@ -4,7 +4,7 @@ use crate::evm::evm::EVM;
 use crate::leviathan::leviathan::LEVIATHAN;
 use crate::leviathan::roleback::Action;
 use crate::leviathan::structs::{
-    BackupSubstate, BlockHeader, ExecutionEnvironment, Log, SubState, Transaction,
+    BackupSubstate, BlockHeader, ExecutionEnvironment, Log, SubState, Transaction, VersionId
 };
 use crate::leviathan::world_state::{Account, Address, WorldState};
 use crate::my_trait::evm_trait::{Gfunction, Hfunction, Ofunction, Xi, Zfunction};
@@ -39,6 +39,7 @@ impl MessageCall for LEVIATHAN {
         }
         self.substate_backup = BackupSubstate::backup(substate); //サブステートのバックアップ
 
+
         //残高の移動
         if eth != U256::ZERO {
             if state.is_empty(&sender) {
@@ -53,6 +54,13 @@ impl MessageCall for LEVIATHAN {
             if sender != recipient {
                 Action::Send_eth(sender.clone(), recipient.clone(), eth).push(self, state); //ロールバック用
                 state.send_eth(&sender, &recipient, eth); //残高の移動
+            }
+        }else if self.version < VersionId::SpuriousDragon {     //Ethereumの初期はvalue=0であっても無条件でアカウントを作成
+            if state.is_empty(&recipient) {
+                if !state.is_physically_exist(&recipient) {
+                    state.add_account(&recipient, Account::new()); //アカウントを追加
+                    Action::Account_creation(recipient.clone()).push(self, state); //アカウントが存在しない場合
+                }
             }
         }
 

--- a/src/leviathan/call.rs
+++ b/src/leviathan/call.rs
@@ -45,8 +45,10 @@ impl MessageCall for LEVIATHAN {
                 return Err((gas, None, None));
             }
             if state.is_empty(&recipient) {
-                state.add_account(&recipient, Account::new()); //アカウントを追加
-                Action::Account_creation(recipient.clone()).push(self, state); //アカウントが存在しない場合
+                if !state.is_physically_exist(&recipient) {
+                    state.add_account(&recipient, Account::new()); //アカウントを追加
+                    Action::Account_creation(recipient.clone()).push(self, state); //アカウントが存在しない場合
+                }
             }
             if sender != recipient {
                 Action::Send_eth(sender.clone(), recipient.clone(), eth).push(self, state); //ロールバック用

--- a/src/leviathan/create.rs
+++ b/src/leviathan/create.rs
@@ -81,8 +81,10 @@ impl ContractCreation for LEVIATHAN {
 
         //Nonceを1にする．
         if state.is_empty(&contract_address) {
-            state.add_account(&contract_address, Account::new()); //アカウントを追加
-            Action::Account_creation(contract_address.clone()).push(self, state); //アカウントが存在しない場合
+            if !state.is_physically_exist(&contract_address) {
+                state.add_account(&contract_address, Account::new()); //アカウントを追加
+                Action::Account_creation(contract_address.clone()).push(self, state); //アカウントが存在しない場合
+            }
         }
         if self.version >= VersionId::SpuriousDragon {
             Action::Add_nonce(contract_address.clone()).push(self, state); //ロールバック用
@@ -93,8 +95,10 @@ impl ContractCreation for LEVIATHAN {
             return Err((gas, None, None));
         }
         if state.is_empty(&contract_address) {
-            state.add_account(&contract_address, Account::new()); //アカウントを追加
-            Action::Account_creation(contract_address.clone()).push(self, state); //アカウントが存在しない場合
+            if !state.is_physically_exist(&contract_address) {
+                state.add_account(&contract_address, Account::new()); //アカウントを追加
+                Action::Account_creation(contract_address.clone()).push(self, state); //アカウントが存在しない場合
+            }
         }
         Action::Send_eth(sender.clone(), contract_address.clone(), eth).push(self, state); //ロールバック用
         state.send_eth(&sender, &contract_address, eth);

--- a/src/leviathan/create.rs
+++ b/src/leviathan/create.rs
@@ -173,7 +173,7 @@ impl ContractCreation for LEVIATHAN {
 
             Err(None) => {
                 //Z関数による停止
-                tracing::info!("[ContractCreation] Revert");
+                tracing::info!("[ContractCreation] 例外停止");
                 self.roleback(state); //Roleback実行
                 substate.road_backup(self.substate_backup.clone()); //SubStateの巻き戻し
                 return Err((U256::ZERO, None, None));

--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -399,7 +399,7 @@ mod state_tests {
             .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
             .try_init();
         // ここにテストしたいディレクトリへのパスを指定します
-        let test_dir = "require/stCallDelegateCodesCallCodeHomestead";
+        let test_dir = "require/stCreateTest";
         //let test_dir = "require/stCallCodes";
         //let test_dir = "testdata/GeneralStateTestsFiller/CompleteTest";
 

--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -187,8 +187,10 @@ impl TransactionExecution for LEVIATHAN {
                 let reimburse = return_gas.saturating_mul(transaction.t_price);
                 if state.is_empty(&sender_address) {
                     //set_balance前の確認
-                    state.add_account(&sender_address, Account::new()); //アカウントを追加
-                    Action::Account_creation(sender_address.clone()).push(self, state); //アカウントが存在しない場合
+                    if !state.is_physically_exist(&sender_address) {
+                        state.add_account(&sender_address, Account::new()); //アカウントを追加
+                        Action::Account_creation(sender_address.clone()).push(self, state); //アカウントが存在しない場合
+                    }
                 }
                 state.set_balance(&sender_address, reimburse);
                 //マイナーへの支払い
@@ -205,8 +207,10 @@ impl TransactionExecution for LEVIATHAN {
                 let reward = final_billed_gas.saturating_mul(f);
                 if state.is_empty(&block_header.h_beneficiary) {
                     //set_balance前の確認
-                    state.add_account(&block_header.h_beneficiary, Account::new()); //アカウントを追加
-                    Action::Account_creation(block_header.h_beneficiary.clone()).push(self, state); //アカウントが存在しない場合
+                    if !state.is_physically_exist(&block_header.h_beneficiary) {
+                        state.add_account(&block_header.h_beneficiary, Account::new()); //アカウントを追加
+                        Action::Account_creation(block_header.h_beneficiary.clone()).push(self, state); //アカウントが存在しない場合
+                    }
                 }
                 state.set_balance(&block_header.h_beneficiary, reward);
                 //substate.a_desの処理
@@ -222,8 +226,10 @@ impl TransactionExecution for LEVIATHAN {
                 let reimburse = gas.saturating_mul(transaction.t_price);
                 if state.is_empty(&sender_address) {
                     //set_balance前の確認
-                    state.add_account(&sender_address, Account::new()); //アカウントを追加
-                    Action::Account_creation(sender_address.clone()).push(self, state); //アカウントが存在しない場合
+                    if !state.is_physically_exist(&sender_address) {
+                        state.add_account(&sender_address, Account::new()); //アカウントを追加
+                        Action::Account_creation(sender_address.clone()).push(self, state); //アカウントが存在しない場合
+                    }
                 }
                 state.set_balance(&sender_address, reimburse);
                 //マイナーへの支払い
@@ -240,8 +246,10 @@ impl TransactionExecution for LEVIATHAN {
                 let reward = final_billed_gas.saturating_mul(f);
                 if state.is_empty(&block_header.h_beneficiary) {
                     //set_balance前の確認
-                    state.add_account(&block_header.h_beneficiary, Account::new()); //アカウントを追加
-                    Action::Account_creation(block_header.h_beneficiary.clone()).push(self, state); //アカウントが存在しない場合
+                    if !state.is_physically_exist(&block_header.h_beneficiary) {
+                        state.add_account(&block_header.h_beneficiary, Account::new()); //アカウントを追加
+                        Action::Account_creation(block_header.h_beneficiary.clone()).push(self, state); //アカウントが存在しない場合
+                    }
                 }
                 state.set_balance(&block_header.h_beneficiary, reward);
                 return Err((final_billed_gas, Vec::new()));

--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -401,7 +401,7 @@ mod state_tests {
         // ここにテストしたいディレクトリへのパスを指定します
         let test_dir = "require/stCreateTest";
         //let test_dir = "require/stCallCodes";
-        //let test_dir = "testdata/GeneralStateTestsFiller/CompleteTest";
+        //let test_dir = "require/stCreate2";
 
         let paths = fs::read_dir(test_dir)
             .unwrap_or_else(|_| panic!("Failed to read test directory: {}", test_dir));

--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -399,7 +399,7 @@ mod state_tests {
             .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
             .try_init();
         // ここにテストしたいディレクトリへのパスを指定します
-        let test_dir = "require/stCallCreateCallCodeTest";
+        let test_dir = "require/stCallDelegateCodesCallCodeHomestead";
         //let test_dir = "require/stCallCodes";
         //let test_dir = "testdata/GeneralStateTestsFiller/CompleteTest";
 

--- a/src/leviathan/state_method.rs
+++ b/src/leviathan/state_method.rs
@@ -182,7 +182,7 @@ impl State for WorldState {
     }
 
     fn add_account(&mut self, address: &Address, account: Account) {
-        //println!("作成された: 0x{}",hex::encode(address.0)); //アドレス
+        tracing::info!("add_accout: 0x{}", hex::encode(address.0));
         self.0.insert(address.clone(), account);
     }
 

--- a/src/leviathan/state_method.rs
+++ b/src/leviathan/state_method.rs
@@ -21,6 +21,14 @@ impl State for WorldState {
         return true;
     }
 
+    fn is_dead(&self, address: &Address) -> bool {
+        //DEADだとtrue
+        if !self.0.contains_key(address) || self.is_empty(address) {
+            return true;
+        }
+        return false;
+    }
+
     fn is_storage_empty(&self, address: &Address) -> bool {
         //空だとtrue;
         let Some(account) = self.0.get(address) else {

--- a/src/leviathan/state_method.rs
+++ b/src/leviathan/state_method.rs
@@ -38,6 +38,10 @@ impl State for WorldState {
         }
     }
 
+    fn is_physically_exist(&self, address: &Address) -> bool { //存在してたらtrue
+        self.0.contains_key(address)
+    }
+                                                               
     fn is_storage_empty(&self, address: &Address) -> bool {
         //空だとtrue;
         let Some(account) = self.0.get(address) else {
@@ -96,7 +100,7 @@ impl State for WorldState {
         let account = self
             .0
             .get_mut(&address)
-            .expect("アカウントが存在しない.事前にadd_account");
+            .expect("[set_balance]アカウントが存在しない.事前にadd_account");
         account.balance += value;
     }
 
@@ -106,7 +110,7 @@ impl State for WorldState {
         let account = self
             .0
             .get_mut(&address)
-            .expect("アカウントが存在しない.事前にadd_account");
+            .expect("[inc_nonce]アカウントが存在しない.事前にadd_account");
         tracing::info!("[inc_nonce]アドレス:0x{}", hex::encode(address.0)); //アドレス
         account.nonce += 1
     }

--- a/src/leviathan/state_method.rs
+++ b/src/leviathan/state_method.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use crate::leviathan::structs::{ExecutionEnvironment, SubState};
+use crate::leviathan::structs::{ExecutionEnvironment, SubState, VersionId};
 use crate::leviathan::world_state::{Account, Address, WorldState};
 use crate::my_trait::leviathan_trait::State;
 use alloy_primitives::{I256, U256, hex};
@@ -21,12 +21,21 @@ impl State for WorldState {
         return true;
     }
 
-    fn is_dead(&self, address: &Address) -> bool {
+    fn is_dead(&self, version:VersionId, address: &Address) -> bool {
         //DEADだとtrue
-        if !self.0.contains_key(address) || self.is_empty(address) {
-            return true;
+        if version < VersionId::SpuriousDragon {
+            if !self.0.contains_key(address) {
+                return true;
+            }else{
+                return false;
+            }
+        }else{
+            if !self.0.contains_key(address) || self.is_empty(address) {
+                return true;
+            }else{
+                return false;
+            }
         }
-        return false;
     }
 
     fn is_storage_empty(&self, address: &Address) -> bool {

--- a/src/my_trait/leviathan_trait.rs
+++ b/src/my_trait/leviathan_trait.rs
@@ -1,11 +1,11 @@
-use crate::leviathan::structs::{BlockHeader, ExecutionEnvironment, Log, SubState, Transaction};
+use crate::leviathan::structs::{BlockHeader, ExecutionEnvironment, Log, SubState, Transaction, VersionId};
 use crate::leviathan::world_state::{Account, Address, WorldState};
 use alloy_primitives::{I256, U256};
 
 pub trait State {
     fn is_empty(&self, address: &Address) -> bool; //空だとtrue;
     
-    fn is_dead(&self, address: &Address) -> bool; //DEADだとtrue
+    fn is_dead(&self, version: VersionId, address: &Address) -> bool; //DEADだとtrue
 
     fn is_storage_empty(&self, address: &Address) -> bool; //空だとtrue;
 

--- a/src/my_trait/leviathan_trait.rs
+++ b/src/my_trait/leviathan_trait.rs
@@ -6,6 +6,8 @@ pub trait State {
     fn is_empty(&self, address: &Address) -> bool; //空だとtrue;
     
     fn is_dead(&self, version: VersionId, address: &Address) -> bool; //DEADだとtrue
+   
+    fn is_physically_exist(&self, address: &Address) -> bool; //存在してたらtrue
 
     fn is_storage_empty(&self, address: &Address) -> bool; //空だとtrue;
 

--- a/src/my_trait/leviathan_trait.rs
+++ b/src/my_trait/leviathan_trait.rs
@@ -4,6 +4,8 @@ use alloy_primitives::{I256, U256};
 
 pub trait State {
     fn is_empty(&self, address: &Address) -> bool; //空だとtrue;
+    
+    fn is_dead(&self, address: &Address) -> bool; //DEADだとtrue
 
     fn is_storage_empty(&self, address: &Address) -> bool; //空だとtrue;
 


### PR DESCRIPTION
## 概要（What）
Yellow PaperおよびEIP-161（Spurious Dragonフォーク）に基づく「DEAD（死んだ）アカウント」の概念をStateに実装した。
これに伴い、`CALL` 系命令におけるアカウント作成コスト（Gas）の算出基準、初期Ethereumにおける無条件のアカウント作成挙動、および `REVERT` 命令のフォーク依存制御を厳密化した。また、状態のロールバック機能（Revert/例外停止時）において、空アカウントが意図せず消失してしまうバグを修正した。

## 背景・課題（Why）
`stCreateTest` などの歴史的なState Testをパスするためには、Ethereumが過去のハードフォークで経てきたステート管理の仕様変更を正確に再現する必要があった。
1. **DEAD vs EMPTY:** Spurious Dragon以前と以降では、「アカウントが存在しない（DEAD）」の定義が異なる。ガスコストの計算（25000ガスの追加請求）は「EMPTY」ではなく「DEAD」を基準に行う必要があった。
2. **レガシーEthereumのCALL挙動:** 初期Ethereumでは、送金額（Value）が0であっても `CALL` を実行しただけで無条件に宛先アカウントが作成される仕様が存在し、State不一致の原因となっていた。
3. **ロールバックの欠陥:** 以前のロールバック機能はアカウントの「物理的な存在」を考慮せず強制的にステートを上書きしていたため、元々存在していたEmptyアカウントがロールバックによってStateから消滅してしまう問題があった。

## 詳細な修正内容（How）

### 1. DEADアカウント概念の実装とGas計算の修正
* **`State.is_dead` の実装:** フォークに応じたDEAD判定を実装。
  * Spurious Dragon以前: 物理的にStateに存在しない場合のみDEAD。
  * Spurious Dragon以降: 「物理的に存在しない」または「EMPTY（Nonce=0, Balance=0, CodeHash=Empty）」の場合にDEAD。
* **`EVM.gas()` の修正:** `CALL` 等のアカウント作成コスト（25000 gas）の請求判定を、アカウントが `empty` かどうかではなく `dead` かどうかに基づいて行うようYellow Paper準拠で修正。

### 2. 初期Ethereumのレガシー仕様の再現
* **`message_call` の修正:** Spurious Dragon以前のフォークにおいて、`CALL` の宛先アカウントが存在しない場合、`Value == 0` であっても無条件でアカウントを作成する初期の仕様を実装した。
* **`REVERT (0xfd)` のフォーク対応:** `REVERT` 命令が定義されていない古いフォークにおいては、未定義オペコードとして正しく「例外停止（Exceptional Halt）」をトリガーするよう変更した。

### 3. ロールバック（Journal）機能の堅牢化
* アカウント作成（`add_account`）のロールバック処理において、State上に物理的にアカウントが存在するかを事前に確認するよう修正。
* 存在しない場合にのみ削除/リセットを行うことで、実行前から存在していたEmptyアカウントを誤ってStateから消去してしまうバグを修正した。

## テスト結果
* `test/stCreateTest` 環境において、Spurious Dragon前後をまたぐ複雑なステート遷移のテストが正しく動作することを確認。