### PR TITLE
fix(core): CODECOPY/EXTCODECOPYのOOB(境界外)コピー挙動のYellow Paper準拠およびstMemoryTest完全制覇

### DIFF
--- a/src/evm/evm.rs
+++ b/src/evm/evm.rs
@@ -5,7 +5,7 @@ use crate::leviathan::structs::{ExecutionEnvironment, SubState, VersionId};
 use crate::leviathan::world_state::{Account, Address, WorldState};
 use crate::my_trait::evm_trait::{Gfunction, Hfunction, Ofunction, Xi, Zfunction};
 use crate::my_trait::leviathan_trait::State;
-use alloy_primitives::{I256, U256};
+use alloy_primitives::{I256, U256, hex};
 
 pub struct EVM {
     pub gas: U256,

--- a/src/evm/execution.rs
+++ b/src/evm/execution.rs
@@ -950,10 +950,10 @@ impl Ofunction for EVM {
         let offset = self.pop().try_into().unwrap_or(usize::MAX);
         let size = self.pop().try_into().unwrap_or(usize::MAX);
         tracing::info!(
-        dest_offset = dest_offset,
-        offset = offset,
-        size = size,
-        "CODECOPY"
+            dest_offset = dest_offset,
+            offset = offset,
+            size = size,
+            "CODECOPY"
         );
         //メモリ拡張
         if size != 0 {
@@ -1876,7 +1876,7 @@ impl Ofunction for EVM {
         //・コールスタック深度
         let is_deepth = execution_environment.i_depth >= 1024;
         if is_deepth {
-            self.gas +=child_gas;
+            self.gas += child_gas;
             self.child_gas_mem = None;
             tracing::warn!("[DELEGATECALL] 事前チェックで例外停止");
             self.push(U256::ZERO);

--- a/src/evm/execution.rs
+++ b/src/evm/execution.rs
@@ -949,6 +949,12 @@ impl Ofunction for EVM {
         let dest_offset = self.pop().try_into().unwrap_or(usize::MAX);
         let offset = self.pop().try_into().unwrap_or(usize::MAX);
         let size = self.pop().try_into().unwrap_or(usize::MAX);
+        tracing::info!(
+        dest_offset = dest_offset,
+        offset = offset,
+        size = size,
+        "CODECOPY"
+        );
         //メモリ拡張
         if size != 0 {
             let required_size = dest_offset.saturating_add(size);
@@ -957,17 +963,17 @@ impl Ofunction for EVM {
                 self.memory.resize(words * 32, 0);
             }
             //メモリに値を書き込む
+            let mut slice = vec![0u8; size];
             let read_size = offset.saturating_add(size);
             if offset <= data.len() {
                 if read_size > data.len() {
                     let copy_len = data.len() - offset;
-                    self.memory[dest_offset..dest_offset + copy_len]
-                        .copy_from_slice(&data[offset..data.len()]);
+                    slice[..copy_len].copy_from_slice(&data[offset..data.len()]);
                 } else {
-                    self.memory[dest_offset..required_size]
-                        .copy_from_slice(&data[offset..read_size]);
+                    slice.copy_from_slice(&data[offset..read_size]);
                 }
             }
+            self.memory[dest_offset..required_size].copy_from_slice(&slice);
         }
         //アクティブなword数を更新
         let active_words = self.memory.len() / 32;
@@ -991,7 +997,7 @@ impl Ofunction for EVM {
         let size = self.pop().try_into().unwrap_or(usize::MAX);
         //コード取得
         let result = state.get_code(&address);
-        let code = match result {
+        let data = match result {
             Some(x) => x,
             None => Vec::<u8>::new(),
         };
@@ -1003,17 +1009,17 @@ impl Ofunction for EVM {
                 self.memory.resize(words * 32, 0);
             }
             //メモリに値を書き込む
+            let mut slice = vec![0u8; size];
             let read_size = offset.saturating_add(size);
-            if offset <= code.len() {
-                if read_size > code.len() {
-                    let copy_len = code.len() - offset;
-                    self.memory[dest_offset..dest_offset + copy_len]
-                        .copy_from_slice(&code[offset..code.len()]);
+            if offset <= data.len() {
+                if read_size > data.len() {
+                    let copy_len = data.len() - offset;
+                    slice[..copy_len].copy_from_slice(&data[offset..data.len()]);
                 } else {
-                    self.memory[dest_offset..required_size]
-                        .copy_from_slice(&code[offset..read_size]);
+                    slice.copy_from_slice(&data[offset..read_size]);
                 }
             }
+            self.memory[dest_offset..required_size].copy_from_slice(&slice);
         }
         //SubStateの更新
         if !substate.a_access.contains(&address) {

--- a/src/evm/safe.rs
+++ b/src/evm/safe.rs
@@ -186,12 +186,12 @@ impl Zfunction for EVM {
         let gas_cost = self.gas(opcode, substate, state, execution_environment);
         if self.gas < gas_cost {
             tracing::warn!(
-                depth = execution_environment.i_depth,
-                opcode = format_args!("0x{:x}",opcode),
-                evm_gas = %self.gas,
-                gas_cost = %gas_cost,
-                "[is_safe]残ガスが足りない"
-                );
+            depth = execution_environment.i_depth,
+            opcode = format_args!("0x{:x}",opcode),
+            evm_gas = %self.gas,
+            gas_cost = %gas_cost,
+            "[is_safe]残ガスが足りない"
+            );
             return false;
         }
 

--- a/src/leviathan/call.rs
+++ b/src/leviathan/call.rs
@@ -4,7 +4,7 @@ use crate::evm::evm::EVM;
 use crate::leviathan::leviathan::LEVIATHAN;
 use crate::leviathan::roleback::Action;
 use crate::leviathan::structs::{
-    BackupSubstate, BlockHeader, ExecutionEnvironment, Log, SubState, Transaction, VersionId
+    BackupSubstate, BlockHeader, ExecutionEnvironment, Log, SubState, Transaction, VersionId,
 };
 use crate::leviathan::world_state::{Account, Address, WorldState};
 use crate::my_trait::evm_trait::{Gfunction, Hfunction, Ofunction, Xi, Zfunction};
@@ -39,7 +39,6 @@ impl MessageCall for LEVIATHAN {
         }
         self.substate_backup = BackupSubstate::backup(substate); //サブステートのバックアップ
 
-
         //残高の移動
         if eth != U256::ZERO {
             if state.is_empty(&sender) {
@@ -55,7 +54,8 @@ impl MessageCall for LEVIATHAN {
                 Action::Send_eth(sender.clone(), recipient.clone(), eth).push(self, state); //ロールバック用
                 state.send_eth(&sender, &recipient, eth); //残高の移動
             }
-        }else if self.version < VersionId::SpuriousDragon {     //Ethereumの初期はvalue=0であっても無条件でアカウントを作成
+        } else if self.version < VersionId::SpuriousDragon {
+            //Ethereumの初期はvalue=0であっても無条件でアカウントを作成
             if state.is_empty(&recipient) {
                 if !state.is_physically_exist(&recipient) {
                     state.add_account(&recipient, Account::new()); //アカウントを追加

--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -407,7 +407,7 @@ mod state_tests {
             .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
             .try_init();
         // ここにテストしたいディレクトリへのパスを指定します
-        let test_dir = "require/stCreateTest";
+        let test_dir = "require/stMemoryTest";
         //let test_dir = "require/stCallCodes";
         //let test_dir = "require/stCreate2";
 

--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -209,7 +209,8 @@ impl TransactionExecution for LEVIATHAN {
                     //set_balance前の確認
                     if !state.is_physically_exist(&block_header.h_beneficiary) {
                         state.add_account(&block_header.h_beneficiary, Account::new()); //アカウントを追加
-                        Action::Account_creation(block_header.h_beneficiary.clone()).push(self, state); //アカウントが存在しない場合
+                        Action::Account_creation(block_header.h_beneficiary.clone())
+                            .push(self, state); //アカウントが存在しない場合
                     }
                 }
                 state.set_balance(&block_header.h_beneficiary, reward);
@@ -248,7 +249,8 @@ impl TransactionExecution for LEVIATHAN {
                     //set_balance前の確認
                     if !state.is_physically_exist(&block_header.h_beneficiary) {
                         state.add_account(&block_header.h_beneficiary, Account::new()); //アカウントを追加
-                        Action::Account_creation(block_header.h_beneficiary.clone()).push(self, state); //アカウントが存在しない場合
+                        Action::Account_creation(block_header.h_beneficiary.clone())
+                            .push(self, state); //アカウントが存在しない場合
                     }
                 }
                 state.set_balance(&block_header.h_beneficiary, reward);
@@ -291,7 +293,7 @@ mod state_tests {
             "EIP150" | "TangerineWhistle" => VersionId::TangerineWhistle,
             "EIP158" | "SpuriousDragon" => VersionId::SpuriousDragon,
             "Byzantium" => VersionId::Byzantium,
-            "Constantinople"  => VersionId::Constantinople,
+            "Constantinople" => VersionId::Constantinople,
             "Petersburg" | "ConstantinopleFix" => VersionId::Petersburg,
             "Istanbul" => VersionId::Istanbul,
             "Berlin" => VersionId::Berlin,

--- a/src/leviathan/state_method.rs
+++ b/src/leviathan/state_method.rs
@@ -21,27 +21,28 @@ impl State for WorldState {
         return true;
     }
 
-    fn is_dead(&self, version:VersionId, address: &Address) -> bool {
+    fn is_dead(&self, version: VersionId, address: &Address) -> bool {
         //DEADだとtrue
         if version < VersionId::SpuriousDragon {
             if !self.0.contains_key(address) {
                 return true;
-            }else{
+            } else {
                 return false;
             }
-        }else{
+        } else {
             if !self.0.contains_key(address) || self.is_empty(address) {
                 return true;
-            }else{
+            } else {
                 return false;
             }
         }
     }
 
-    fn is_physically_exist(&self, address: &Address) -> bool { //存在してたらtrue
+    fn is_physically_exist(&self, address: &Address) -> bool {
+        //存在してたらtrue
         self.0.contains_key(address)
     }
-                                                               
+
     fn is_storage_empty(&self, address: &Address) -> bool {
         //空だとtrue;
         let Some(account) = self.0.get(address) else {

--- a/src/my_trait/leviathan_trait.rs
+++ b/src/my_trait/leviathan_trait.rs
@@ -1,12 +1,14 @@
-use crate::leviathan::structs::{BlockHeader, ExecutionEnvironment, Log, SubState, Transaction, VersionId};
+use crate::leviathan::structs::{
+    BlockHeader, ExecutionEnvironment, Log, SubState, Transaction, VersionId,
+};
 use crate::leviathan::world_state::{Account, Address, WorldState};
 use alloy_primitives::{I256, U256};
 
 pub trait State {
     fn is_empty(&self, address: &Address) -> bool; //空だとtrue;
-    
+
     fn is_dead(&self, version: VersionId, address: &Address) -> bool; //DEADだとtrue
-   
+
     fn is_physically_exist(&self, address: &Address) -> bool; //存在してたらtrue
 
     fn is_storage_empty(&self, address: &Address) -> bool; //空だとtrue;


### PR DESCRIPTION
## 概要（What）
`stMemoryTest` の全テストパスに向けて、`CODECOPY` および `EXTCODECOPY` オペコードにおける境界外（Out of Bounds）からのデータコピー挙動をYellow Paperの仕様に完全準拠するよう修正した。
コピー元のデータ長を超える `offset` が指定された場合でも、EVMのメモリ上に安全に `0` がパディングされるようにアルゴリズムを最適化し、これをもって `stMemoryTest` カテゴリの全テストをパスした。

## 背景・課題（Why）
以前の実装では、コピー開始地点（`offset`）がコピー元コードのサイズより大きい場合、処理をスキップ（何もしない）する挙動となっていた。
しかし、Yellow Paperの仕様では「EVM上のすべてのデータは無限長であり、実際のデータ長を超える部分はすべて `0` で埋められている」と定義されている。そのため、本来はデータ長を超えた `offset` から読み取った場合も `0` をコピー先に書き込むのが正しい挙動であった。

**【セキュリティ・パフォーマンス上の課題】**
仕様通りに「コピー元のデータを `offset` まで `0` で拡張して読み取る」という愚直な実装をした場合、悪意のあるコントラクトが極端に巨大な `offset` を指定した際にVMのメモリ（ホストマシンの物理メモリ）が枯渇し、パニック（OOMクラッシュ）を引き起こす脆弱性があった。

## 詳細な修正内容（How）

### 1. 安全なゼロパディングアルゴリズムの実装
`CODECOPY` および `EXTCODECOPY` の内部処理を以下の通り修正し、VMに負荷をかけずに無限長の `0` パディング仕様を再現した。
* 要求された `size` 分の全て `0` で初期化されたバイト配列（バッファ）を先にアロケートする。
* `offset` が実際のデータ長より小さい（有効なデータが含まれる）場合のみ、存在するデータをそのバッファに安全に上書きコピーする。
* `offset` がデータ長を超える場合は、初期化された `0` のバッファをそのままメモリのコピー先へ展開する。

これにより、巨大な `offset` が指定されても必要な `size` 分のメモリしか確保されず、ホストの安全性を保ったままYellow Paperの仕様を完全に満たすことができた。

### 2. コードフォーマットとテスト確認
* `cargo fmt` を実行し、スタイリングを統一。
* `test/stMemoryTest` における全てのテストケースがパス（Success）することを確認した。