### PR TITLE
feat(core): SELFDESTRUCTの二重返金防止およびフォーク別ガスコスト(EXP, BALANCE等)の厳格化

### DIFF
--- a/src/evm/execution.rs
+++ b/src/evm/execution.rs
@@ -241,7 +241,7 @@ impl Ofunction for EVM {
                 let to_address = Address::from_u256(val1);
                 //デバック用
                 tracing::info!(
-                    recipient =  format_args!("0x{}", hex::encode(to_address.0)),
+                    recipient = format_args!("0x{}", hex::encode(to_address.0)),
                     "SELFDESTRUCT"
                 );
                 let balance = state.get_balance(&from_address).unwrap();
@@ -390,9 +390,9 @@ impl Ofunction for EVM {
                     self.active_words = active_words;
                 }
                 tracing::info!(
-                    return_gas = %return_gas,
-                    "[CALL] normal end:"
-                    );
+                return_gas = %return_gas,
+                "[CALL] normal end:"
+                );
                 //Returndata バッファの更新
                 self.return_back = return_data;
                 //ガスの精算

--- a/src/evm/execution.rs
+++ b/src/evm/execution.rs
@@ -231,12 +231,19 @@ impl Ofunction for EVM {
 
             0xff => {
                 //SELFDESTRUCT
-                if self.version < VersionId::London {
-                    substate.a_reimburse += 24000;
-                }
                 let from_address = &execution_environment.i_address;
+                if self.version < VersionId::London {
+                    if !substate.a_des.contains(&from_address) {
+                        substate.a_reimburse += 24000;
+                    }
+                }
                 let val1 = self.pop();
                 let to_address = Address::from_u256(val1);
+                //デバック用
+                tracing::info!(
+                    recipient =  format_args!("0x{}", hex::encode(to_address.0)),
+                    "SELFDESTRUCT"
+                );
                 let balance = state.get_balance(&from_address).unwrap();
                 if from_address.clone() == to_address {
                     Action::Set_balance(from_address.clone(), U256::ZERO).push(leviathan, state); //ロールバック用
@@ -382,6 +389,10 @@ impl Ofunction for EVM {
                     let active_words = self.memory.len() / 32; //アクティブなword数を更新
                     self.active_words = active_words;
                 }
+                tracing::info!(
+                    return_gas = %return_gas,
+                    "[CALL] normal end:"
+                    );
                 //Returndata バッファの更新
                 self.return_back = return_data;
                 //ガスの精算

--- a/src/evm/gas.rs
+++ b/src/evm/gas.rs
@@ -209,15 +209,15 @@ impl Gfunction for EVM {
                 return total;
             }
 
-            0x31  => {
+            0x31 => {
                 //BALANCE
                 if self.version < VersionId::TangerineWhistle {
                     return U256::from(20);
-                }else if self.version < VersionId::Istanbul {
+                } else if self.version < VersionId::Istanbul {
                     return U256::from(400);
-                }else if self.version < VersionId::Berlin {
+                } else if self.version < VersionId::Berlin {
                     return U256::from(700);
-                }else{
+                } else {
                     //Address型に変換
                     let data = self.peek(0);
                     let cost = self.is_account_access(data, substate);
@@ -229,9 +229,9 @@ impl Gfunction for EVM {
                 //EXTCODESIZE
                 if self.version < VersionId::TangerineWhistle {
                     return U256::from(20);
-                }else if self.version < VersionId::Berlin {
+                } else if self.version < VersionId::Berlin {
                     return U256::from(700);
-                }else{
+                } else {
                     //Address型に変換
                     let data = self.peek(0);
                     let cost = self.is_account_access(data, substate);

--- a/src/evm/gas.rs
+++ b/src/evm/gas.rs
@@ -209,12 +209,34 @@ impl Gfunction for EVM {
                 return total;
             }
 
-            0x31 | 0x3b => {
+            0x31  => {
                 //BALANCE
-                //Address型に変換
-                let data = self.peek(0);
-                let cost = self.is_account_access(data, substate);
-                return U256::from(cost);
+                if self.version < VersionId::TangerineWhistle {
+                    return U256::from(20);
+                }else if self.version < VersionId::Istanbul {
+                    return U256::from(400);
+                }else if self.version < VersionId::Berlin {
+                    return U256::from(700);
+                }else{
+                    //Address型に変換
+                    let data = self.peek(0);
+                    let cost = self.is_account_access(data, substate);
+                    return U256::from(cost);
+                }
+            }
+
+            0x3b => {
+                //EXTCODESIZE
+                if self.version < VersionId::TangerineWhistle {
+                    return U256::from(20);
+                }else if self.version < VersionId::Berlin {
+                    return U256::from(700);
+                }else{
+                    //Address型に変換
+                    let data = self.peek(0);
+                    let cost = self.is_account_access(data, substate);
+                    return U256::from(cost);
+                }
             }
 
             0x3f => {

--- a/src/evm/gas.rs
+++ b/src/evm/gas.rs
@@ -182,7 +182,7 @@ impl Gfunction for EVM {
                 let byte = (bit + 7) / 8;
                 let byte_u256 = U256::from(byte);
 
-                if self.version == VersionId::Frontier {
+                if self.version < VersionId::SpuriousDragon {
                     let result = byte_u256
                         .saturating_mul(U256::from(10))
                         .saturating_add(U256::from(10));

--- a/src/evm/safe.rs
+++ b/src/evm/safe.rs
@@ -47,7 +47,7 @@ static SAFE_TABLE: [[u8; 2]; 256] = {
 
     // Environmental Information
     table[0x30] = [0, 1]; // ADDRESS
-    table[0x31] = [2, 1]; // BALANCE
+    table[0x31] = [1, 1]; // BALANCE
     table[0x32] = [0, 1]; // ORIGIN
     table[0x33] = [0, 1]; // CALLER
     table[0x34] = [0, 1]; // CALLVALUE
@@ -170,7 +170,7 @@ impl Zfunction for EVM {
         //現在の命令が要求する要素数に対して，スタックの中身は足りるか？
         let pop_number = op_info[0] as usize;
         if self.stack.len() < pop_number {
-            tracing::warn!("スタックの中身が足りない");
+            tracing::warn!("スタックの中身が足りない: 0x{:x}",opcode);
             return false;
         }
 

--- a/src/evm/safe.rs
+++ b/src/evm/safe.rs
@@ -170,7 +170,7 @@ impl Zfunction for EVM {
         //現在の命令が要求する要素数に対して，スタックの中身は足りるか？
         let pop_number = op_info[0] as usize;
         if self.stack.len() < pop_number {
-            tracing::warn!("スタックの中身が足りない: 0x{:x}",opcode);
+            tracing::warn!("スタックの中身が足りない: 0x{:x}", opcode);
             return false;
         }
 

--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -39,6 +39,7 @@ impl TransactionExecution for LEVIATHAN {
         transaction: Transaction,
         block_header: &BlockHeader,
     ) -> Result<(U256, Vec<Log>), (U256, Vec<Log>)> {
+        tracing::info!("version: {:?}", self.version);
         //=======ステップ1===========
         //【初期ガスの計算】
         let base_gas = U256::from(21000); //基本料金

--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -409,7 +409,7 @@ mod state_tests {
             .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
             .try_init();
         // ここにテストしたいディレクトリへのパスを指定します
-        let test_dir = "require/stMemoryTest";
+        let test_dir = "require/stRefundTest";
         //let test_dir = "require/stCallCodes";
         //let test_dir = "require/stCreate2";
 


### PR DESCRIPTION
## 概要（What）
`stRefundTest` の制覇に向け、`SELFDESTRUCT` 実行時における二重返金（Double Refund）を防止するロジックをYellow Paperに基づいて実装した。
また、`EXP`、`EXTCODESIZE`、`BALANCE` などのオペコードに対して、ハードフォークの歴史（Spurious DragonやTangerine Whistle等）に合わせた厳密なガスコスト計算を導入した。合わせて、事前検証関数におけるスタック要求数のバグ修正を行った。

## 背景・課題（Why）
1. **SELFDESTRUCTの二重返金問題:**
   同一トランザクション内で同じコントラクトが複数回 `SELFDESTRUCT` を呼び出した場合、これまでの実装ではその都度24,000ガスの返金（Refund）が加算される状態だった。Yellow Paperの仕様では、一度削除リストA_desに登録されたアカウントへの重複返金は禁止されているため、テストパニックの原因となっていた。
2. **フォークによるガスコストの変動:**
   EVMの歴史において、DoS攻撃対策などの理由で特定のオペコードのガスコストが大幅に変更されている。
   * `EXP`: 指数部のバイトあたりのコストが変更（10 gas → 50 gas 等）。
   * `EXTCODESIZE` / `BALANCE`: ステートアクセスを伴うため、コストが引き上げられた歴史がある。
   これらのフォーク依存のガス計算がハードコードされていたため、テストの期待値と残ガスにズレが生じていた。

## 詳細な修正内容（How）

### 1. SELFDESTRUCT (0xff) の二重返金防止
* `EVM.execution` 内の `SELFDESTRUCT` 処理において、対象アカウントがすでに現在のトランザクションのサブステート（削除リスト）に登録されているかを確認するチェック機構を実装。
* 未登録の場合にのみ24,000ガスの返金（Refund）を行うよう修正し、Yellow Paperの仕様に完全準拠させた。

### 2. フォーク別ガスコストの動的計算（EVM.gas）
* `EVM.gas` において、実行中のフォークバージョンを判定するロジックを追加。
* `EXP` (0x0A): 指数部のサイズに応じた追加ガスコストをフォークごとに適切に計算するよう修正。
* `BALANCE` (0x31) / `EXTCODESIZE` (0x3B): フォークごとの基本ガスコストの変動に対応。

### 3. is_safe関数のスタック検証バグ修正
* `BALANCE` (0x31) オペコードの実行に必要なスタック要素数を `2` から `1` （アドレスのみ）に修正し、スタックアンダーフロー等の誤検知を防いだ。

### 4. コードフォーマット
* `cargo fmt` を適用し、コードの可読性とスタイリングを統一した。

## テスト結果
* ローカル環境にてガス消費量とRefund量が仕様通りに計算されることを確認。`test/stRefundTest` の突破に向けた基盤が完了した。