### PR TITLE
refactor(core): Stateトレイトのget系メソッドを &mut self へ変更（キャッシュ機構対応）

### DIFF
--- a/src/evm/gas.rs
+++ b/src/evm/gas.rs
@@ -166,7 +166,7 @@ impl Gfunction for EVM {
         &mut self,
         opcode: u8,
         substate: &SubState,
-        state: &WorldState,
+        state: &mut WorldState,
         execution_environment: &ExecutionEnvironment,
     ) -> U256 {
         let used_gas = GAS_TABLE[opcode as usize];

--- a/src/evm/safe.rs
+++ b/src/evm/safe.rs
@@ -142,7 +142,7 @@ impl Zfunction for EVM {
         &mut self,
         opcode: u8,
         substate: &SubState,
-        state: &WorldState,
+        state: &mut WorldState,
         execution_environment: &ExecutionEnvironment,
     ) -> bool {
         //不正な命令の実行確認

--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -430,9 +430,9 @@ mod state_tests {
             .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
             .try_init();
         // ここにテストしたいディレクトリへのパスを指定します
-        //let test_dir = "GeneralStateTestsFiller/stWalletTest";
+        let test_dir = "GeneralStateTestsFiller/stWalletTest";
         //let test_dir = "GeneralStateTestsFiller/stCallCodes";
-        let test_dir = "GeneralStateTestsFiller/stCreate2";
+        //let test_dir = "GeneralStateTestsFiller/stCreate2";
 
         let paths = fs::read_dir(test_dir)
             .unwrap_or_else(|_| panic!("Failed to read test directory: {}", test_dir));

--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -757,7 +757,7 @@ mod state_tests {
                         }
 
                         if let Some(expected_nonce_str) = &expected_acc.nonce {
-                            let expected_nonce: u32 =
+                            let expected_nonce: u64 =
                                 parse_u256(expected_nonce_str).try_into().unwrap_or(0);
                             assert_eq!(
                                 actual_acc.nonce, expected_nonce,

--- a/src/leviathan/mpt_method.rs
+++ b/src/leviathan/mpt_method.rs
@@ -1,0 +1,28 @@
+#![allow(dead_code)]
+
+use crate::leviathan::structs::VersionId;
+use crate::leviathan::world_state::{Account, WorldState};
+use crate::my_trait::leviathan_trait::State;
+use alloy_primitives::{U256, hex, Address};
+
+impl State for WorldState2 {
+    fn add_account(&mut self, address: &Address, account: Account) {
+        self.cache.insert(address.clone(), account);
+    }
+
+    fn is_empty(&self, address: &Address) -> bool {
+        //まずcacheに存在するか確認
+        if self.cache.contains_key(address) {
+            let account = self.0.get(address).unwrap();
+            if account.nonce != 0
+                || !account.balance.is_zero()
+                || account.code.len() != 0
+                || !account.storage.is_empty()
+            {
+                return false;
+            }
+        }else{
+            //次にMPTに存在するか確認
+
+
+

--- a/src/leviathan/roleback.rs
+++ b/src/leviathan/roleback.rs
@@ -20,7 +20,7 @@ pub enum Action {
 }
 
 impl Action {
-    pub fn push(self, leviathan: &mut LEVIATHAN, state: &WorldState) {
+    pub fn push(self, leviathan: &mut LEVIATHAN, state: &mut WorldState) {
         let action = match self {
             Action::Sstorage(address, key, _) => {
                 let pre_value = state

--- a/src/leviathan/state_method.rs
+++ b/src/leviathan/state_method.rs
@@ -6,7 +6,7 @@ use crate::my_trait::leviathan_trait::State;
 use alloy_primitives::{U256, hex, Address};
 
 impl State for WorldState {
-    fn is_empty(&self, address: &Address) -> bool {
+    fn is_empty(&mut self, address: &Address) -> bool {
         //空だとtrue;
         if self.0.contains_key(address) {
             let account = self.0.get(address).unwrap();
@@ -21,7 +21,7 @@ impl State for WorldState {
         true
     }
 
-    fn is_dead(&self, version: VersionId, address: &Address) -> bool {
+    fn is_dead(&mut self, version: VersionId, address: &Address) -> bool {
         //DEADだとtrue
         if version < VersionId::SpuriousDragon {
             !self.0.contains_key(address)
@@ -30,12 +30,12 @@ impl State for WorldState {
         }
     }
 
-    fn is_physically_exist(&self, address: &Address) -> bool {
+    fn is_physically_exist(&mut self, address: &Address) -> bool {
         //存在してたらtrue
         self.0.contains_key(address)
     }
 
-    fn is_storage_empty(&self, address: &Address) -> bool {
+    fn is_storage_empty(&mut self, address: &Address) -> bool {
         //空だとtrue;
         let Some(account) = self.0.get(address) else {
             return true;
@@ -43,7 +43,7 @@ impl State for WorldState {
         account.storage.is_empty()
     }
 
-    fn get_balance(&self, address: &Address) -> Option<U256> {
+    fn get_balance(&mut self, address: &Address) -> Option<U256> {
         if !self.0.contains_key(address) {
             return None;
         }
@@ -52,7 +52,7 @@ impl State for WorldState {
         Some(value)
     }
 
-    fn get_code(&self, address: &Address) -> Option<Vec<u8>> {
+    fn get_code(&mut self, address: &Address) -> Option<Vec<u8>> {
         if !self.0.contains_key(address) {
             return None;
         }
@@ -61,7 +61,7 @@ impl State for WorldState {
         Some(code)
     }
 
-    fn get_storage_value(&self, address: &Address, key: &U256) -> Option<U256> {
+    fn get_storage_value(&mut self, address: &Address, key: &U256) -> Option<U256> {
         if !self.0.contains_key(address) {
             return None;
         }
@@ -71,7 +71,7 @@ impl State for WorldState {
         Some(value.cloned().unwrap_or(U256::from(0)))
     }
 
-    fn get_nonce(&self, address: &Address) -> Option<u64> {
+    fn get_nonce(&mut self, address: &Address) -> Option<u64> {
         if !self.0.contains_key(address) {
             return None;
         }
@@ -81,7 +81,7 @@ impl State for WorldState {
     }
 
     //非推奨
-    fn get_account(&self, address: &Address) -> Account {
+    fn get_account(&mut self, address: &Address) -> Account {
         let account = self.0.get(address);
         match account {
             Some(x) => x.clone(),

--- a/src/leviathan/state_method.rs
+++ b/src/leviathan/state_method.rs
@@ -71,7 +71,7 @@ impl State for WorldState {
         Some(value.cloned().unwrap_or(U256::from(0)))
     }
 
-    fn get_nonce(&self, address: &Address) -> Option<u32> {
+    fn get_nonce(&self, address: &Address) -> Option<u64> {
         if !self.0.contains_key(address) {
             return None;
         }

--- a/src/leviathan/world_state.rs
+++ b/src/leviathan/world_state.rs
@@ -17,10 +17,9 @@ pub struct WorldState2{
 }
 
 impl WorldState2 {
-    //data:Arc<MemoryDB> = Arc::new(MemoryDB::new(true))
-    pub fn new(data: Arc<MemoryDB>) -> Self {
+    pub fn new() -> Self {
+        let data = Arc::new(MemoryDB::new(true));
         let cash = HashMap::<Address, Account>::new();
-        let data = data;
         let eth_trie = EthTrie::new(data.clone());
         let code_storage = HashMap::<B256, Vec<u8>>::new();
 

--- a/src/leviathan/world_state.rs
+++ b/src/leviathan/world_state.rs
@@ -10,16 +10,16 @@ use alloy_rlp::{RlpEncodable, RlpDecodable};
 pub struct WorldState(pub HashMap<Address, Account>);
 
 pub struct WorldState2{
-    cache: HashMap<Address, CacheAccount>,
-    data: Arc<MemoryDB>,
-    eth_trie: EthTrie<MemoryDB>,
-    code_storage: HashMap<B256, Vec<u8>>
+    pub cache: HashMap<Address, Account>,
+    pub data: Arc<MemoryDB>,
+    pub eth_trie: EthTrie<MemoryDB>,
+    pub code_storage: HashMap<B256, Vec<u8>>
 }
 
 impl WorldState2 {
     pub fn new() -> Self {
         let data = Arc::new(MemoryDB::new(true));
-        let cache = HashMap::<Address, CacheAccount>::new();
+        let cache = HashMap::<Address, Account>::new();
         let eth_trie = EthTrie::new(data.clone());
         let mut code_storage = HashMap::<B256, Vec<u8>>::new();
         //空のコードのハッシュを登録
@@ -30,8 +30,12 @@ impl WorldState2 {
         Self {cache, data, eth_trie, code_storage}
     }
 
-    pub fn add_cache(accout: &MptAccount) {
-
+    pub fn add_cache(&mut self, address: Address, mpt_accout: &MptAccount) {
+        let nonce = mpt_accout.nonce;
+        let balance = mpt_accout.balance;
+        let code = self.code_storage.get(&mpt_accout.code_hash).cloned().unwrap();
+        let account = Account::make(nonce, balance, code);
+        self.cache.insert(address, account);
     }
 
 }

--- a/src/leviathan/world_state.rs
+++ b/src/leviathan/world_state.rs
@@ -16,6 +16,20 @@ pub struct WorldState2{
     code_storage: HashMap<B256, Vec<u8>>
 }
 
+impl WorldState2 {
+    //data:Arc<MemoryDB> = Arc::new(MemoryDB::new(true))
+    pub fn new(data: Arc<MemoryDB>) -> Self {
+        let cash = HashMap::<Address, Account>::new();
+        let data = data;
+        let eth_trie = EthTrie::new(data.clone());
+        let code_storage = HashMap::<B256, Vec<u8>>::new();
+
+        Self {cash, data, eth_trie, code_storage}
+    }
+}
+        
+
+
 #[derive(Debug, Clone, RlpEncodable, RlpDecodable)]
 pub struct MptAccount { //MPT専用
     pub nonce: u64,

--- a/src/leviathan/world_state.rs
+++ b/src/leviathan/world_state.rs
@@ -10,7 +10,7 @@ use alloy_rlp::{RlpEncodable, RlpDecodable};
 pub struct WorldState(pub HashMap<Address, Account>);
 
 pub struct WorldState2{
-    cache: HashMap<Address, Account>,
+    cache: HashMap<Address, CacheAccount>,
     data: Arc<MemoryDB>,
     eth_trie: EthTrie<MemoryDB>,
     code_storage: HashMap<B256, Vec<u8>>
@@ -19,7 +19,7 @@ pub struct WorldState2{
 impl WorldState2 {
     pub fn new() -> Self {
         let data = Arc::new(MemoryDB::new(true));
-        let cache = HashMap::<Address, Account>::new();
+        let cache = HashMap::<Address, CacheAccount>::new();
         let eth_trie = EthTrie::new(data.clone());
         let mut code_storage = HashMap::<B256, Vec<u8>>::new();
         //空のコードのハッシュを登録
@@ -29,6 +29,11 @@ impl WorldState2 {
 
         Self {cache, data, eth_trie, code_storage}
     }
+
+    pub fn add_cache(accout: &MptAccount) {
+
+    }
+
 }
         
 
@@ -52,10 +57,18 @@ impl MptAccount {
 }
 
 
+#[derive(Debug, Clone)]
+pub struct CacheAccount {
+    pub nonce: u64,
+    pub balance: U256,
+    pub storage: HashMap<U256, U256>,
+    pub code: B256,
+}
+
 
 #[derive(Debug, Clone)]
 pub struct Account {
-    pub nonce: u32,
+    pub nonce: u64,
     pub balance: U256,
     pub storage: HashMap<U256, U256>,
     pub code: Vec<u8>,
@@ -70,10 +83,16 @@ impl Default for Account {
 impl Account {
     pub fn new() -> Self {
         Self {
-            nonce: 0u32,
+            nonce: 0u64,
             balance: U256::ZERO,
             storage: HashMap::new(),
             code: Vec::new(),
         }
     }
+
+    pub fn make(nonce: u64, balance: U256, code: Vec<u8>) -> Self {
+        let storage = HashMap::<U256, U256>::new();
+        Self {nonce, balance, storage, code}
+    }
+
 }

--- a/src/leviathan/world_state.rs
+++ b/src/leviathan/world_state.rs
@@ -1,16 +1,16 @@
 #![allow(dead_code)]
 
-use alloy_primitives::{U256, B256, Address};
+use alloy_primitives::{U256, B256, Address, keccak256};
 use sha3::Digest;
 use std::collections::HashMap;
 use std::sync::Arc;
-use eth_trie::{MemoryDB, EthTrie};
+use eth_trie::{MemoryDB, EthTrie, Trie};
 use alloy_rlp::{RlpEncodable, RlpDecodable};
 
 pub struct WorldState(pub HashMap<Address, Account>);
 
 pub struct WorldState2{
-    cash: HashMap<Address, Account>,
+    cache: HashMap<Address, Account>,
     data: Arc<MemoryDB>,
     eth_trie: EthTrie<MemoryDB>,
     code_storage: HashMap<B256, Vec<u8>>
@@ -19,11 +19,15 @@ pub struct WorldState2{
 impl WorldState2 {
     pub fn new() -> Self {
         let data = Arc::new(MemoryDB::new(true));
-        let cash = HashMap::<Address, Account>::new();
+        let cache = HashMap::<Address, Account>::new();
         let eth_trie = EthTrie::new(data.clone());
-        let code_storage = HashMap::<B256, Vec<u8>>::new();
+        let mut code_storage = HashMap::<B256, Vec<u8>>::new();
+        //空のコードのハッシュを登録
+        let empty_code = Vec::<u8>::new();
+        let hash = keccak256(&empty_code);
+        code_storage.insert(hash, empty_code);
 
-        Self {cash, data, eth_trie, code_storage}
+        Self {cache, data, eth_trie, code_storage}
     }
 }
         
@@ -36,6 +40,17 @@ pub struct MptAccount { //MPT専用
     pub storage_root: B256, 
     pub code_hash: B256,
 }
+
+impl MptAccount {
+    pub fn new(state: &mut WorldState2)  -> Self{
+        //storage_root取得
+        let mut storage_trie = EthTrie::new(state.data.clone());
+        let storage_root = storage_trie.root_hash().unwrap();
+        let code_hash = alloy_primitives::KECCAK256_EMPTY;
+        Self {nonce: 0u64, balance: U256::ZERO, storage_root, code_hash}
+    }
+}
+
 
 
 #[derive(Debug, Clone)]

--- a/src/my_trait/evm_trait.rs
+++ b/src/my_trait/evm_trait.rs
@@ -23,7 +23,7 @@ pub trait Gfunction {
         &mut self,
         opcode: u8,
         substate: &SubState,
-        state: &WorldState,
+        state: &mut WorldState,
         execution_environment: &ExecutionEnvironment,
     ) -> U256;
 
@@ -38,7 +38,7 @@ pub trait Zfunction {
         &mut self,
         opcode: u8,
         substate: &SubState,
-        state: &WorldState,
+        state: &mut WorldState,
         execution_environment: &ExecutionEnvironment,
     ) -> bool;
 }

--- a/src/my_trait/leviathan_trait.rs
+++ b/src/my_trait/leviathan_trait.rs
@@ -17,7 +17,7 @@ pub trait State {
 
     fn get_storage_value(&self, address: &Address, key: &U256) -> Option<U256>;
 
-    fn get_nonce(&self, address: &Address) -> Option<u32>;
+    fn get_nonce(&self, address: &Address) -> Option<u64>;
 
     fn get_account(&self, address: &Address) -> Account;
 

--- a/src/my_trait/leviathan_trait.rs
+++ b/src/my_trait/leviathan_trait.rs
@@ -3,23 +3,23 @@ use crate::leviathan::world_state::{Account, WorldState};
 use alloy_primitives::{U256, Address};
 
 pub trait State {
-    fn is_empty(&self, address: &Address) -> bool; //空だとtrue;
+    fn is_empty(&mut self, address: &Address) -> bool; //空だとtrue;
 
-    fn is_dead(&self, version: VersionId, address: &Address) -> bool; //DEADだとtrue
+    fn is_dead(&mut self, version: VersionId, address: &Address) -> bool; //DEADだとtrue
 
-    fn is_physically_exist(&self, address: &Address) -> bool; //存在してたらtrue
+    fn is_physically_exist(&mut self, address: &Address) -> bool; //存在してたらtrue
 
-    fn is_storage_empty(&self, address: &Address) -> bool; //空だとtrue;
+    fn is_storage_empty(&mut self, address: &Address) -> bool; //空だとtrue;
 
-    fn get_balance(&self, address: &Address) -> Option<U256>;
+    fn get_balance(&mut self, address: &Address) -> Option<U256>;
 
-    fn get_code(&self, address: &Address) -> Option<Vec<u8>>;
+    fn get_code(&mut self, address: &Address) -> Option<Vec<u8>>;
 
-    fn get_storage_value(&self, address: &Address, key: &U256) -> Option<U256>;
+    fn get_storage_value(&mut self, address: &Address, key: &U256) -> Option<U256>;
 
-    fn get_nonce(&self, address: &Address) -> Option<u64>;
+    fn get_nonce(&mut self, address: &Address) -> Option<u64>;
 
-    fn get_account(&self, address: &Address) -> Account;
+    fn get_account(&mut self, address: &Address) -> Account;
 
     // 書き込み系
     fn set_balance(&mut self, address: &Address, value: U256);


### PR DESCRIPTION
## 概要（What）
MPT（Merkle Patricia Trie）実装およびそれに伴うキャッシュ機構の導入に向け、`leviathan_trait.rs` に定義されている `State` トレイトの `get` 系メソッドの第一引数を `&self` から `&mut self` に変更した。
このトレイトの仕様変更に伴い、`state_method.rs` の実装および、これに依存する諸関数の呼び出し元を可変参照を利用するように修正した。

## 背景・課題（Why）
EVMのステート管理をMPTに移行するにあたり、データベース（Trie）からの読み出し負荷を下げるための「キャッシュ機構」の実装が必須となる。
キャッシュにデータを追加・更新するためには自身の状態を変更する必要があるが、既存の `get` 系メソッドは不変参照（`&self`）を要求するシグネチャとなっていた。


## 詳細な修正内容（How）

### 1. トレイト定義の修正
* `leviathan_trait.rs`: `State` トレイトに定義されている読み取り系メソッド（`get_account` 等）の引数を `&self` から `&mut self` に変更。

### 2. 依存関係の修正
* `state_method.rs`: トレイトの変更に合わせて、各メソッドの実装を可変参照を扱うように書き換え。
* 呼び出し元の諸関数: `get` 系メソッドを呼び出している `EVM` 実行ループや事前チェック処理において、`State` を可変で借用（`&mut`）するように修正を適用した。

