### PR TITLE
refactor(core): 残高更新メソッドの明確化（set_balance -> add_balance）および不要なActionの削除

### DIFF
--- a/src/evm/execution.rs
+++ b/src/evm/execution.rs
@@ -244,7 +244,7 @@ impl Ofunction for EVM {
                 );
                 let balance = state.get_balance(from_address).unwrap();
                 if from_address.clone() == to_address {
-                    Action::SetBalance(from_address.clone(), U256::ZERO).push(leviathan, state); //ロールバック用
+                    Action::ResetBalance(from_address.clone(), U256::ZERO).push(leviathan, state); //ロールバック用
                     state.reset_balance(from_address)
                 } else {
                     if balance != U256::ZERO {

--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -186,13 +186,13 @@ impl TransactionExecution for LEVIATHAN {
                 //送信者への返金
                 let reimburse = return_gas.saturating_mul(transaction.t_price);
                 if state.is_empty(&sender_address) {
-                    //set_balance前の確認
+                    //add_balance前の確認
                     if !state.is_physically_exist(&sender_address) {
                         state.add_account(&sender_address, Account::new()); //アカウントを追加
                         Action::AccountCreation(sender_address.clone()).push(self, state); //アカウントが存在しない場合
                     }
                 }
-                state.set_balance(&sender_address, reimburse);
+                state.add_balance(&sender_address, reimburse);
                 //マイナーへの支払い
                 let final_billed_gas = transaction.t_gas_limit.saturating_sub(return_gas);
                 let f = if self.version < VersionId::London {
@@ -202,14 +202,14 @@ impl TransactionExecution for LEVIATHAN {
                 };
                 let reward = final_billed_gas.saturating_mul(f);
                 if state.is_empty(&block_header.h_beneficiary) {
-                    //set_balance前の確認
+                    //add_balance前の確認
                     if !state.is_physically_exist(&block_header.h_beneficiary) {
                         state.add_account(&block_header.h_beneficiary, Account::new()); //アカウントを追加
                         Action::AccountCreation(block_header.h_beneficiary.clone())
                             .push(self, state); //アカウントが存在しない場合
                     }
                 }
-                state.set_balance(&block_header.h_beneficiary, reward);
+                state.add_balance(&block_header.h_beneficiary, reward);
                 //デバック用
                 tracing::info!(
                     beneficiary =  format_args!("0x{}", hex::encode(block_header.h_beneficiary.0)),
@@ -229,13 +229,13 @@ impl TransactionExecution for LEVIATHAN {
                 //送信者への返金
                 let reimburse = gas.saturating_mul(transaction.t_price);
                 if state.is_empty(&sender_address) {
-                    //set_balance前の確認
+                    //add_balance前の確認
                     if !state.is_physically_exist(&sender_address) {
                         state.add_account(&sender_address, Account::new()); //アカウントを追加
                         Action::AccountCreation(sender_address.clone()).push(self, state); //アカウントが存在しない場合
                     }
                 }
-                state.set_balance(&sender_address, reimburse);
+                state.add_balance(&sender_address, reimburse);
                 //マイナーへの支払い
                 let final_billed_gas = transaction.t_gas_limit.saturating_sub(gas);
                 let f = if self.version < VersionId::London {
@@ -245,14 +245,14 @@ impl TransactionExecution for LEVIATHAN {
                 };
                 let reward = final_billed_gas.saturating_mul(f);
                 if state.is_empty(&block_header.h_beneficiary) {
-                    //set_balance前の確認
+                    //add_balance前の確認
                     if !state.is_physically_exist(&block_header.h_beneficiary) {
                         state.add_account(&block_header.h_beneficiary, Account::new()); //アカウントを追加
                         Action::AccountCreation(block_header.h_beneficiary.clone())
                             .push(self, state); //アカウントが存在しない場合
                     }
                 }
-                state.set_balance(&block_header.h_beneficiary, reward);
+                state.add_balance(&block_header.h_beneficiary, reward);
                 //デバック用
                 tracing::info!(
                     beneficiary =  format_args!("0x{}", hex::encode(block_header.h_beneficiary.0)),

--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -189,7 +189,6 @@ impl TransactionExecution for LEVIATHAN {
                     //add_balance前の確認
                     if !state.is_physically_exist(&sender_address) {
                         state.add_account(&sender_address, Account::new()); //アカウントを追加
-                        Action::AccountCreation(sender_address.clone()).push(self, state); //アカウントが存在しない場合
                     }
                 }
                 state.add_balance(&sender_address, reimburse);
@@ -205,8 +204,6 @@ impl TransactionExecution for LEVIATHAN {
                     //add_balance前の確認
                     if !state.is_physically_exist(&block_header.h_beneficiary) {
                         state.add_account(&block_header.h_beneficiary, Account::new()); //アカウントを追加
-                        Action::AccountCreation(block_header.h_beneficiary.clone())
-                            .push(self, state); //アカウントが存在しない場合
                     }
                 }
                 state.add_balance(&block_header.h_beneficiary, reward);
@@ -232,7 +229,6 @@ impl TransactionExecution for LEVIATHAN {
                     //add_balance前の確認
                     if !state.is_physically_exist(&sender_address) {
                         state.add_account(&sender_address, Account::new()); //アカウントを追加
-                        Action::AccountCreation(sender_address.clone()).push(self, state); //アカウントが存在しない場合
                     }
                 }
                 state.add_balance(&sender_address, reimburse);
@@ -248,8 +244,6 @@ impl TransactionExecution for LEVIATHAN {
                     //add_balance前の確認
                     if !state.is_physically_exist(&block_header.h_beneficiary) {
                         state.add_account(&block_header.h_beneficiary, Account::new()); //アカウントを追加
-                        Action::AccountCreation(block_header.h_beneficiary.clone())
-                            .push(self, state); //アカウントが存在しない場合
                     }
                 }
                 state.add_balance(&block_header.h_beneficiary, reward);

--- a/src/leviathan/mpt_method.rs
+++ b/src/leviathan/mpt_method.rs
@@ -181,7 +181,7 @@ impl State for WorldState2 {
     //=============Setterメソッド===============
     //事前にチェックして，&mut self系は呼ぶ
     //パニックは絶対に生じない
-    fn set_balance(&mut self, address: &Address, value: U256) {
+    fn add_balance(&mut self, address: &Address, value: U256) {
         let cache_account = self.cache.get_mut(address)
             .expect("[set_balance]アカウントが存在しない.事前にadd_account");
         cache_account.balance += value;

--- a/src/leviathan/mpt_method.rs
+++ b/src/leviathan/mpt_method.rs
@@ -178,6 +178,21 @@ impl State for WorldState2 {
         Some(mpt_account.nonce)
     }
 
+    //=============Setterメソッド===============
+    //事前にチェックして，&mut self系は呼ぶ
+    //パニックは絶対に生じない
+    fn set_balance(&mut self, address: &Address, value: U256) {
+        let cache_account = self.cache.get_mut(address)
+            .expect("[set_balance]アカウントが存在しない.事前にadd_account");
+        cache_account.balance += value;
+    }
+
+    fn inc_nonce(&mut self, address: &Address) {
+        let cache_account = self.cache.get_mut(address)
+            .expect("[inc_nonce]アカウントが存在しない.事前にadd_account");
+        tracing::info!("[inc_nonce]アドレス:0x{}", hex::encode(address.0)); //アドレス
+        cache_account.nonce += 1
+    }
 
     fn reset_storage(&mut self, address: &Address) {
         //アカウントがcacheにある前提

--- a/src/leviathan/roleback.rs
+++ b/src/leviathan/roleback.rs
@@ -15,7 +15,7 @@ pub enum Action {
     StoreCode(Address, Vec<u8>),
     AccountCreation(Address),
     ResetStorage(Address, HashMap<U256, U256>),     //(Address, B256)
-    SetBalance(Address, U256),
+    ResetBalance(Address, U256),
 }
 
 impl Action {
@@ -50,9 +50,9 @@ impl Action {
                 Action::ResetStorage(address, storage)
             }
 
-            Action::SetBalance(address, _) => {
+            Action::ResetBalance(address, _) => {
                 let pre_value = state.get_balance(&address).unwrap_or(U256::ZERO);
-                Action::SetBalance(address, pre_value)
+                Action::ResetBalance(address, pre_value)
             }
         };
         leviathan.journal.push(action);
@@ -101,8 +101,8 @@ impl RoleBack for LEVIATHAN {
                      */
                 }
 
-                Action::SetBalance(address, pre_value) => {
-                    state.set_balance(&address, pre_value);
+                Action::ResetBalance(address, pre_value) => {
+                    state.add_balance(&address, pre_value);
                 }
 
                 _ => return Err("不明なAction"),

--- a/src/leviathan/roleback.rs
+++ b/src/leviathan/roleback.rs
@@ -97,6 +97,7 @@ impl RoleBack for LEVIATHAN {
                     /*
                      * let cache_account = state.cache.get_mut(&address).unwrap();
                      * cache_account.storage_hash = storage;
+                     * cache_account.storage.clear();
                      */
                 }
 

--- a/src/leviathan/state_method.rs
+++ b/src/leviathan/state_method.rs
@@ -81,7 +81,7 @@ impl State for WorldState {
     }
 
 
-    fn set_balance(&mut self, address: &Address, value: U256) {
+    fn add_balance(&mut self, address: &Address, value: U256) {
         let account = self
             .0
             .get_mut(address)

--- a/src/my_trait/leviathan_trait.rs
+++ b/src/my_trait/leviathan_trait.rs
@@ -21,7 +21,7 @@ pub trait State {
 
 
     // 書き込み系
-    fn set_balance(&mut self, address: &Address, value: U256);
+    fn add_balance(&mut self, address: &Address, value: U256);
 
     fn inc_nonce(&mut self, address: &Address);
 


### PR DESCRIPTION
## 概要（What）
EVMコアエンジンにおけるアカウント残高の更新処理に関して、メソッドおよび `Action` Enumの命名規則を見直し、責務を明確化した。
具体的には、従来の `set_balance` を `add_balance` に変更し、絶対値での上書き操作を意味する `SetBalance` を `ResetBalance` へとリネームした。また、トランザクションの最終確定工程（State Clearing）において、不要となっていたロールバック用のアクション（`Action::AddAccount`）の記録処理を削除した。

## 背景・課題（Why）
1. **命名と実際の挙動の不一致:**
   これまで `State` トレイトや `WorldState` に実装されていた `set_balance` メソッドは、名前から「残高を指定した値で上書き（Set）する」操作を連想させるが、実際には内部で「既存の残高に対する加算（Add / Sub）」を行っていた。この不一致は、今後のMPT実装や複雑なオペコード（例: `SELFDESTRUCT` の送金など）の実装においてバグの温床となるため、実態に即した `add_balance` に修正する必要があった。
2. **Actionの責務分離:**
   ロールバックの記録として使われる `Action` においても、同様の理由で `SetBalance` を `ResetBalance` にリネームし、「特定の残高状態に巻き戻す（リセットする）」という意図を明確にした。
3. **最終工程のオーバーヘッド:**
   トランザクションの最終工程（`leviathan.rs` の後処理など）は、すでに状態が確定（Commit）するフェーズであり、以降でロールバックが発生することはアーキテクチャ上あり得ない。そのため、ここで `Action::AddAccount` をジャーナルに `push` するのはメモリと処理の無駄であった。

## 詳細な修正内容（How）

### 1. メソッドのリネーム（Add系）
* `State` トレイト、およびそれを実装する `WorldState`, `WorldState2` において、`set_balance()` を `add_balance()` にリネームし、呼び出し元（`leviathan.rs` 等）をすべて修正した。

### 2. Actionの整理（Reset系）
* ジャーナルに記録される `Action::SetBalance` を `Action::ResetBalance` にリネーム。
* `EVM.execution()` 内の該当箇所を `ResetBalance` を発行するように修正した。

### 3. 最終工程の最適化
* `leviathan.rs` のトランザクション最終確定工程から、不要な `Action::AddAccount` をジャーナルへ `push` する処理を削除した。
