### PR TITLE
feat(core): Touched Accounts (a_touch) の実装およびMPT同期ロジックの強化（StateTest制覇へ向けて）

### DIFF
--- a/src/evm/execution.rs
+++ b/src/evm/execution.rs
@@ -237,6 +237,10 @@ impl Ofunction for EVM {
                 }
                 let val1 = self.pop();
                 let to_address = Address::from_word(B256::from(val1.to_be_bytes::<32>()));
+                //サブステートのa_touchに追加
+                if !substate.a_touch.contains(&to_address) {
+                    substate.a_touch.push(to_address.clone())
+                }
                 //デバック用
                 tracing::info!(
                     recipient = format_args!("0x{}", hex::encode(to_address.0)),
@@ -312,6 +316,10 @@ impl Ofunction for EVM {
             data = slice.to_vec();
         } else {
             data = Vec::<u8>::new();
+        }
+        //サブステートのa_touchに追加
+        if !substate.a_touch.contains(&to_address) {
+            substate.a_touch.push(to_address.clone())
         }
         //アクセス済みリストの更新
         if !substate.a_access.contains(&to_address) {
@@ -1517,6 +1525,10 @@ impl Ofunction for EVM {
                 self.return_back = Vec::<u8>::new();
                 //新しいコントラクトアドレス
                 let contract_u256 = U256::from_be_bytes(contract_address.into_word().0);
+                //サブステートのa_touchに追加
+                if !substate.a_touch.contains(&contract_address) {
+                    substate.a_touch.push(contract_address.clone())
+                }
                 //アクセス済みリストの更新
                 if !substate.a_access.contains(&contract_address) {
                     substate.a_access.push(contract_address.clone())
@@ -1641,6 +1653,10 @@ impl Ofunction for EVM {
                 self.return_back = Vec::<u8>::new();
                 //新しいコントラクトアドレス
                 let contract_u256 = U256::from_be_bytes(contract_address.into_word().0);
+                //サブステートのa_touchに追加
+                if !substate.a_touch.contains(&contract_address) {
+                    substate.a_touch.push(contract_address.clone())
+                }
                 //アクセス済みリストの更新
                 if !substate.a_access.contains(&contract_address) {
                     substate.a_access.push(contract_address.clone())
@@ -1714,6 +1730,10 @@ impl Ofunction for EVM {
             data = slice.to_vec();
         } else {
             data = Vec::<u8>::new();
+        }
+        //サブステートのa_touchに追加
+        if !substate.a_touch.contains(&to_address) {
+            substate.a_touch.push(to_address.clone())
         }
         //アクセス済みリストの更新
         if !substate.a_access.contains(&to_address) {
@@ -1872,6 +1892,10 @@ impl Ofunction for EVM {
             self.push(U256::ZERO);
             return;
         };
+        //サブステートのa_touchに追加
+        if !substate.a_touch.contains(&to_address) {
+            substate.a_touch.push(to_address.clone())
+        }
         //アクセス済みリストの更新
         if !substate.a_access.contains(&to_address) {
             substate.a_access.push(to_address.clone())
@@ -2003,6 +2027,10 @@ impl Ofunction for EVM {
             data = slice.to_vec();
         } else {
             data = Vec::<u8>::new();
+        }
+        //サブステートのa_touchに追加
+        if !substate.a_touch.contains(&to_address) {
+            substate.a_touch.push(to_address.clone())
         }
         //アクセス済みリストの更新
         if !substate.a_access.contains(&to_address) {

--- a/src/leviathan/create.rs
+++ b/src/leviathan/create.rs
@@ -85,6 +85,11 @@ impl ContractCreation for LEVIATHAN {
             return Err((U256::ZERO, None, None));
         }
 
+        //サブステートのa_touchに追加
+        if !substate.a_touch.contains(&contract_address) {
+            substate.a_touch.push(contract_address.clone())
+        }
+
         //サブステートのアクセス済みアカウントに追加
         if !substate.a_access.contains(&contract_address) {
             substate.a_access.push(contract_address.clone())

--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -226,10 +226,6 @@ impl TransactionExecution for LEVIATHAN {
                 //substate.a_touchの処理
                 while let Some(address) = substate.a_touch.pop() {
                     if state.is_dead(self.version,&address) {
-                        tracing::info!(
-                            empty_accout = format_args!("0x{}", hex::encode(address)),
-                            "[a_touchの処理]",
-                            );
                         let address_hash = keccak256(address);
                         state.eth_trie.remove(address_hash.as_slice());
                         state.cache.remove(&address);
@@ -291,11 +287,23 @@ impl TransactionExecution for LEVIATHAN {
                     let address_hash = keccak256(address);
                     let mut mpt_account_rlp_bytes = Vec::new();
                     mpt_account.encode(&mut mpt_account_rlp_bytes);
-                    //アカウントは変化しているのかを確認
-                    let new_mpt_account_hash = keccak256(mpt_account_rlp_bytes.clone());
-                    if new_mpt_account_hash != cache_account.account_hash {
-                        tracing::debug!("更新");
-                        println!("Address: {}, RLP: {}", address, hex::encode(&mpt_account_rlp_bytes));
+
+                    //MPTに現在登録されているRLPを取得
+                    let existing_mpt_val = state.eth_trie.get(address_hash.as_slice()).unwrap_or(None);
+
+                    // 更新すべきか判定
+                    let should_insert = match existing_mpt_val {
+                        None => true, // MPTに存在しない（新規アカウント）なら絶対に挿入
+                        Some(old_rlp) => {
+                            // MPTに存在するなら、RLPの中身が変化している場合のみ挿入
+                            old_rlp != mpt_account_rlp_bytes
+                        }
+                    };
+
+                    // 更新
+                    if should_insert {
+                        tracing::debug!("更新: 0x{}", hex::encode(address));
+                        let _ = state.eth_trie.remove(address_hash.as_slice());
                         state.eth_trie.insert(address_hash.as_slice(), mpt_account_rlp_bytes.as_slice()).unwrap();
                     }
                 }
@@ -393,9 +401,22 @@ impl TransactionExecution for LEVIATHAN {
                     let address_hash = keccak256(address);
                     let mut mpt_account_rlp_bytes = Vec::new();
                     mpt_account.encode(&mut mpt_account_rlp_bytes);
-                    //アカウントは変化しているのかを確認
-                    let new_mpt_account_hash = keccak256(mpt_account_rlp_bytes.clone());
-                    if new_mpt_account_hash != cache_account.account_hash {
+                    //MPTに現在登録されているRLPを取得
+                    let existing_mpt_val = state.eth_trie.get(address_hash.as_slice()).unwrap_or(None);
+
+                    // 更新すべきか判定
+                    let should_insert = match existing_mpt_val {
+                        None => true, // MPTに存在しない（新規アカウント）なら絶対に挿入
+                        Some(old_rlp) => {
+                            // MPTに存在するなら、RLPの中身が変化している場合のみ挿入
+                            old_rlp != mpt_account_rlp_bytes
+                        }
+                    };
+
+                    // 更新
+                    if should_insert {
+                        tracing::debug!("更新: 0x{}", hex::encode(address));
+                        let _ = state.eth_trie.remove(address_hash.as_slice());
                         state.eth_trie.insert(address_hash.as_slice(), mpt_account_rlp_bytes.as_slice()).unwrap();
                     }
                 }

--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -223,6 +223,18 @@ impl TransactionExecution for LEVIATHAN {
                     final_billed_gas = %final_billed_gas,
                     "[マイナーへの支払い]",
                 );
+                //substate.a_touchの処理
+                while let Some(address) = substate.a_touch.pop() {
+                    if state.is_dead(self.version,&address) {
+                        tracing::info!(
+                            empty_accout = format_args!("0x{}", hex::encode(address)),
+                            "[a_touchの処理]",
+                            );
+                        let address_hash = keccak256(address);
+                        state.eth_trie.remove(address_hash.as_slice());
+                        state.cache.remove(&address);
+                    }
+                }
                 //substate.a_desの処理
                 while let Some(address) = substate.a_des.pop() {
                     let address_hash = keccak256(address);
@@ -326,6 +338,14 @@ impl TransactionExecution for LEVIATHAN {
                     final_billed_gas = %final_billed_gas,
                     "[Err:マイナーへの支払い]",
                 );
+                //substate.a_touchの処理
+                while let Some(address) = substate.a_touch.pop() {
+                    if state.is_dead(self.version,&address) {
+                        let address_hash = keccak256(address);
+                        state.eth_trie.remove(address_hash.as_slice());
+                        state.cache.remove(&address);
+                    }
+                }
                 //substate.a_desの処理
                 while let Some(address) = substate.a_des.pop() {
                     let address_hash = keccak256(address);
@@ -552,7 +572,7 @@ mod state_tests {
             .try_init();
 
         // 対象のディレクトリ
-        let test_dir = "MPTTest/stCallCodes";
+        let test_dir = "MPTTest/stCallCreateCallCodeTest";
 
         let paths = std::fs::read_dir(test_dir)
             .unwrap_or_else(|_| panic!("Failed to read test directory: {}", test_dir));

--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -113,6 +113,10 @@ impl TransactionExecution for LEVIATHAN {
         //ここからロールバックの起点:ロールバックが起きたらこの状態にする
         let mut substate = SubState::new();
 
+        //a_touchにトランザクションの基本要素（送信者，ブロックの受取人）を追加
+        substate.a_touch.push(sender_address.clone());
+        substate.a_touch.push(block_header.h_beneficiary.clone());
+
         //gasから初期ガスを引く
         let mut gas = gas.unwrap();
         gas = gas.saturating_sub(all_gas);
@@ -144,6 +148,8 @@ impl TransactionExecution for LEVIATHAN {
             )
         } else {
             let to_address = transaction.t_to.unwrap();
+            //a_touchにトランザクションの基本要素（宛先）を追加
+            substate.a_touch.push(to_address.clone());
             //デバック出力
             tracing::info!(
             sender_address =  format_args!("0x{}", hex::encode(sender_address.0)),

--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -593,7 +593,7 @@ mod state_tests {
             .try_init();
 
         // 対象のディレクトリ
-        let test_dir = "MPTTest/stCallCreateCallCodeTest";
+        let test_dir = "MPTTest/stWalletTest";
 
         let paths = std::fs::read_dir(test_dir)
             .unwrap_or_else(|_| panic!("Failed to read test directory: {}", test_dir));

--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -593,7 +593,7 @@ mod state_tests {
             .try_init();
 
         // 対象のディレクトリ
-        let test_dir = "MPTTest/stWalletTest";
+        let test_dir = "MPTTest/stInitCodeTest";
 
         let paths = std::fs::read_dir(test_dir)
             .unwrap_or_else(|_| panic!("Failed to read test directory: {}", test_dir));


### PR DESCRIPTION
## 概要

Ethereumプロトコルにおけるステートクリアリングの前提となる「Touched Accounts（触れられたアカウント: a_touch）」のトラッキングと処理機構を実装した。
また、トランザクション最終工程における「キャッシュからMPTへの書き戻しロジック」を改修し、キャッシュで新規作成されたアカウントがMPTへ正しく挿入されるよう条件を強化した。
結果として、複雑な呼び出し・生成ロジックを含む stCallCreateCallCodeTest および stInitCodeTest を完全にパスすることに成功した。

## 課題

### Touched Accoutsの必要性
Ethereumの仕様（EIP-161等）において、残高がゼロの空アカウントは「そのトランザクション内で触れられた（Touched）場合のみ」削除対象となる。これまでこのトラッキングが未実装だったため、厳密なステートの最終確定（State Clearing）に不足があった。

### MPT同期ロジックの盲点
前回の最適化で「キャッシュとMPTのハッシュ（account_hash）を比較し、差分がある場合のみ更新する」ロジックを実装した。しかし、「元々MPTに存在せず、今回のトランザクションで初めてキャッシュ上に生成されたアカウント（コントラクト等）」のハンドリングが漏れており、ステートに正しく反映されないケースが存在した。

## 修正内容

### a_touchトラッキングの実装
トランザクション実行中の各フェーズにおいて、仕様通りにアカウントアドレスを SubState.a_touch に記録する機能を追加した。

- **トランザクション基盤**: 送信者（Sender）、宛先（Destination）、およびブロック報酬受取人（Coinbase）。

- **オペコード実行時**: メッセージコール系（CALL, CALLCODE, DELEGATECALL, STATICCALL）の宛先アドレス。

- **コントラクト生成**: CREATE, CREATE2 オペコードによって新規作成されるコントラクトアドレス。

- 破棄: SELFDESTRUCT (0xff) 実行時の残高受取人（Beneficiary）アドレス。

### トランザクション最終工程の改修

- TransactionExecution の最終フェーズにおいて、記録された a_touch を処理・評価するロジックを実装した。
- キャッシュからMPTへアカウントを書き戻す判定条件を拡張。従来の「ハッシュの差分比較」に加え、「MPTには存在しないが、キャッシュには存在する（＝新規作成された）」 場合も条件として検知し、確実にMPTへ insert するようロジックを修正した。


## 検証結果

- ロジック改修後、難関であった stCallCreateCallCodeTest および stInitCodeTest を正常にパスすることを確認した。

- 既存のロジック破壊（リグレッション）が発生していないか確認テストを実行し、以前パスしていた全てのテストケースが引き続き問題なくパスすることを担保した。
