### PR TITLE
feat(core): stCreateTest突破！ContractCreationのロールバック適正化およびSELFDESTRUCTの歴史的仕様の完全実装

### DIFF
--- a/src/evm/execution.rs
+++ b/src/evm/execution.rs
@@ -1528,14 +1528,6 @@ impl Ofunction for EVM {
                 self.return_back = Vec::<u8>::new();
                 //新しいコントラクトアドレス
                 let contract_u256 = U256::from_be_bytes(contract_address.into_word().0);
-                //サブステートのa_touchに追加
-                if !substate.a_touch.contains(&contract_address) {
-                    substate.a_touch.push(contract_address.clone())
-                }
-                //アクセス済みリストの更新
-                if !substate.a_access.contains(&contract_address) {
-                    substate.a_access.push(contract_address.clone())
-                }
                 tracing::info!("CREATE:0x{}", hex::encode(contract_address.0)); //アドレス
                 //Journalのmerge
                 leviathan.merge(*child_leviathan);
@@ -1656,14 +1648,6 @@ impl Ofunction for EVM {
                 self.return_back = Vec::<u8>::new();
                 //新しいコントラクトアドレス
                 let contract_u256 = U256::from_be_bytes(contract_address.into_word().0);
-                //サブステートのa_touchに追加
-                if !substate.a_touch.contains(&contract_address) {
-                    substate.a_touch.push(contract_address.clone())
-                }
-                //アクセス済みリストの更新
-                if !substate.a_access.contains(&contract_address) {
-                    substate.a_access.push(contract_address.clone())
-                }
                 tracing::info!("CREATE2:0x{}", hex::encode(contract_address.0)); //アドレス
                 //Journalのmerge
                 leviathan.merge(*child_leviathan);

--- a/src/evm/execution.rs
+++ b/src/evm/execution.rs
@@ -241,20 +241,23 @@ impl Ofunction for EVM {
                 if !substate.a_touch.contains(&to_address) {
                     substate.a_touch.push(to_address.clone())
                 }
+                let balance = state.get_balance(from_address).unwrap();
                 //デバック用
                 tracing::info!(
                     recipient = format_args!("0x{}", hex::encode(to_address.0)),
+                    from_address_balance = %balance,
                     "SELFDESTRUCT"
                 );
-                let balance = state.get_balance(from_address).unwrap();
                 if from_address.clone() == to_address {
                     Action::ResetBalance(from_address.clone(), U256::ZERO).push(leviathan, state); //ロールバック用
                     state.reset_balance(from_address)
+                }else if self.version <= VersionId::TangerineWhistle  && balance == U256::ZERO{
+                    if state.is_empty(&to_address) && !state.is_physically_exist(&to_address) {
+                        state.add_account(&to_address, Account::new()); //アカウントを追加
+                        Action::AccountCreation(to_address.clone()).push(leviathan, state); //アカウントが存在しない場合
+                    }
                 } else {
                     if balance != U256::ZERO {
-                        if state.is_empty(from_address) {
-                            return Some(false);
-                        }
                         if state.is_empty(&to_address) && !state.is_physically_exist(&to_address) {
                             state.add_account(&to_address, Account::new()); //アカウントを追加
                             Action::AccountCreation(to_address.clone()).push(leviathan, state); //アカウントが存在しない場合

--- a/src/evm/gas.rs
+++ b/src/evm/gas.rs
@@ -637,13 +637,13 @@ impl Gfunction for EVM {
                     let my_address = &execution_environment.i_address;
                     let balance = state.get_balance(my_address).unwrap_or(U256::ZERO);
                     let create_cost = if self.version >= VersionId::SpuriousDragon{
-                        if balance > U256::ZERO && state.is_empty(&address){
+                        if balance > U256::ZERO && !state.is_physically_exist(&address){
                             25000
                         } else {
                             0
                         }
                     }else{
-                        if state.is_empty(&address){
+                        if !state.is_physically_exist(&address){
                             25000
                         } else {
                             0

--- a/src/evm/gas.rs
+++ b/src/evm/gas.rs
@@ -635,13 +635,19 @@ impl Gfunction for EVM {
                     let address = Address::from_word(B256::from(data.to_be_bytes::<32>()));
                     //新規アカウント作成のペナルティ
                     let my_address = &execution_environment.i_address;
-                    let create_cost = if state.get_balance(my_address).unwrap_or(U256::from(0))
-                        > U256::from(0)
-                        && state.is_empty(&address)
-                    {
-                        25000
-                    } else {
-                        0
+                    let balance = state.get_balance(my_address).unwrap_or(U256::ZERO);
+                    let create_cost = if self.version >= VersionId::SpuriousDragon{
+                        if balance > U256::ZERO && state.is_empty(&address){
+                            25000
+                        } else {
+                            0
+                        }
+                    }else{
+                        if state.is_physically_exist(&address){
+                            25000
+                        } else {
+                            0
+                        }
                     };
                     let access_state_cost = 0usize;
                     if self.version > VersionId::Berlin {

--- a/src/evm/gas.rs
+++ b/src/evm/gas.rs
@@ -643,7 +643,7 @@ impl Gfunction for EVM {
                             0
                         }
                     }else{
-                        if state.is_physically_exist(&address){
+                        if state.is_empty(&address){
                             25000
                         } else {
                             0

--- a/src/leviathan/create.rs
+++ b/src/leviathan/create.rs
@@ -85,10 +85,6 @@ impl ContractCreation for LEVIATHAN {
             return Err((U256::ZERO, None, None));
         }
 
-        //サブステートのa_touchに追加
-        if !substate.a_touch.contains(&contract_address) {
-            substate.a_touch.push(contract_address.clone())
-        }
 
         //サブステートのアクセス済みアカウントに追加
         if !substate.a_access.contains(&contract_address) {
@@ -96,6 +92,10 @@ impl ContractCreation for LEVIATHAN {
         }
         self.substate_backup = BackupSubstate::backup(substate); //サブステートのバックアップ
 
+        //サブステートのa_touchに追加
+        if !substate.a_touch.contains(&contract_address) {
+            substate.a_touch.push(contract_address.clone())
+        }
         //Nonceを1にする．
         if state.is_empty(&contract_address) && !state.is_physically_exist(&contract_address) {
             state.add_account(&contract_address, Account::new()); //アカウントを追加

--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -593,7 +593,7 @@ mod state_tests {
             .try_init();
 
         // 対象のディレクトリ
-        let test_dir = "MPTTest/stInitCodeTest";
+        let test_dir = "MPTTest/stCreateTest";
 
         let paths = std::fs::read_dir(test_dir)
             .unwrap_or_else(|_| panic!("Failed to read test directory: {}", test_dir));

--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -347,6 +347,7 @@ impl TransactionExecution for LEVIATHAN {
                     "[Err:マイナーへの支払い]",
                 );
                 //substate.a_touchの処理
+                tracing::debug!("{:?}", substate.a_touch);
                 while let Some(address) = substate.a_touch.pop() {
                     if state.is_dead(self.version,&address) {
                         let address_hash = keccak256(address);


### PR DESCRIPTION
## 概要
MPTアーキテクチャ上で stCreateTest を完全にパスすることに成功した。
本PRでは、コントラクト作成（ContractCreation）時における a_touch（Touched Accounts）への登録タイミングを修正し、例外停止時のロールバック機構と同期させた。また、SELFDESTRUCT オペコードおよびゼロ送金時のアカウント作成挙動について、FrontierからSpurious Dragonに至るまでの歴史的なフォークごとのエッジケース（ガス計算およびアカウント存在判定）を厳密に実装した。

## 課題

### a_touchのロールバック不整合
これまでの実装では、ContractCreation関数において，SubState.a_accessと同じタイミングでa_touchを更新していた．
結果として，コントラクト作成が失敗した場合，a_touchに作成したアカウントが記録されたままとなり，ステートが予期したものと異なった状態となっていた．

### 歴史的フォークによるアカウント作成ルールの違い:
EthereumはSpurious Dragonフォーク前後で、空アカウント（Empty Account）の扱いや作成コストに関するルールが劇的に変化している。

- Frontier ~ Tangerine Whistle: 送金額が0（ゼロ）であっても、宛先アカウントが存在しなければ強制的にアカウントを作成するレガシー仕様が存在する。

- Spurious Dragon以前の SELFDESTRUCT: 送金額に関わらず、未知のアカウントを作成した場合は一律で25,000ガスの追加ペナルティを請求する仕様への対応が漏れていた。

## 詳細な修正内容

### ContractCreation および a_touch の最適化

- ContractCreation 関数内において、新規作成したアカウントを a_touch へ登録するタイミングを修正し、処理がロールバックされた際には a_touch からも該当アカウントが正確に消去される（元に戻る）ようにした。

- 上記の修正に伴い、EVM.execution() 側の CREATE / CREATE2 オペコード内に存在していた、成功時の a_access および a_touch への重複した追加ロジックを削除し、責務を整理した。


### EVM.gas() における SELFDESTRUCT (0xff) の仕様修正

 - ガス計算時のアカウント存在判定ロジックが反転していたバグを修正。
 - 判定メソッドを is_empty から、物理的なストレージの存在を正確に問う is_physically_exist へ変更し、ステートの誤認を防止。
 -  Spurious Dragonフォーク以前の環境において、SELFDESTRUCT による新規アカウント作成時には送金額に関わらず25,000ガスを請求するロジックを追加した。
 

## 結果
- stCreateTestを突破した
- ロールバックやガス計算のコアロジックに手を入れたが、過去にパスした全てのStateTest（stCallCreateCallCodeTest, stInitCodeTest など）を再実行し、破壊的変更（リグレッション）が一切発生しておらず、全て問題なく作動することを確認した。