### PR TITLE
refactor(core): Yellow Paper準拠のアカウント状態管理（is_emptyの廃止とis_deadへの統合）

### DIFF
--- a/src/evm/execution.rs
+++ b/src/evm/execution.rs
@@ -257,13 +257,13 @@ impl Ofunction for EVM {
                     Action::ResetBalance(from_address.clone(), U256::ZERO).push(leviathan, state); //ロールバック用
                     state.reset_balance(from_address)
                 }else if self.version <= VersionId::TangerineWhistle  && balance == U256::ZERO{
-                    if state.is_empty(&to_address) && !state.is_physically_exist(&to_address) {
+                    if state.is_dead(self.version, &to_address) && !state.is_physically_exist(&to_address) {
                         state.add_account(&to_address, Account::new()); //アカウントを追加
                         Action::AccountCreation(to_address.clone()).push(leviathan, state); //アカウントが存在しない場合
                     }
                 } else {
                     if balance != U256::ZERO {
-                        if state.is_empty(&to_address) && !state.is_physically_exist(&to_address) {
+                        if state.is_dead(self.version, &to_address) && !state.is_physically_exist(&to_address) {
                             state.add_account(&to_address, Account::new()); //アカウントを追加
                             Action::AccountCreation(to_address.clone()).push(leviathan, state); //アカウントが存在しない場合
                         }

--- a/src/leviathan/call.rs
+++ b/src/leviathan/call.rs
@@ -41,10 +41,10 @@ impl MessageCall for LEVIATHAN {
 
         //残高の移動
         if eth != U256::ZERO {
-            if state.is_empty(&sender) {
+            if state.is_dead(self.version, &sender) {
                 return Err((gas, None, None));
             }
-            if state.is_empty(&recipient) && !state.is_physically_exist(&recipient) {
+            if state.is_dead(self.version, &recipient) && !state.is_physically_exist(&recipient) {
                 state.add_account(&recipient, Account::new()); //アカウントを追加
                 Action::AccountCreation(recipient.clone()).push(self, state); //アカウントが存在しない場合
             }
@@ -54,7 +54,7 @@ impl MessageCall for LEVIATHAN {
             }
         } else if self.version < VersionId::SpuriousDragon {
             //Ethereumの初期はvalue=0であっても無条件でアカウントを作成
-            if state.is_empty(&recipient) && !state.is_physically_exist(&recipient) {
+            if state.is_dead(self.version, &recipient) && !state.is_physically_exist(&recipient) {
                 state.add_account(&recipient, Account::new()); //アカウントを追加
                 Action::AccountCreation(recipient.clone()).push(self, state); //アカウントが存在しない場合
             }

--- a/src/leviathan/create.rs
+++ b/src/leviathan/create.rs
@@ -97,7 +97,7 @@ impl ContractCreation for LEVIATHAN {
             substate.a_touch.push(contract_address.clone())
         }
         //Nonceを1にする．
-        if state.is_empty(&contract_address) && !state.is_physically_exist(&contract_address) {
+        if state.is_dead(self.version, &contract_address) && !state.is_physically_exist(&contract_address) {
             state.add_account(&contract_address, Account::new()); //アカウントを追加
             Action::AccountCreation(contract_address.clone()).push(self, state); //アカウントが存在しない場合
         }
@@ -106,10 +106,10 @@ impl ContractCreation for LEVIATHAN {
             state.inc_nonce(&contract_address);
         }
         //送金する
-        if state.is_empty(&sender) {
+        if state.is_dead(self.version, &sender) {
             return Err((gas, None, None));
         }
-        if state.is_empty(&contract_address) && !state.is_physically_exist(&contract_address) {
+        if state.is_dead(self.version, &contract_address) && !state.is_physically_exist(&contract_address) {
             state.add_account(&contract_address, Account::new()); //アカウントを追加
             Action::AccountCreation(contract_address.clone()).push(self, state); //アカウントが存在しない場合
         }

--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -100,7 +100,7 @@ impl TransactionExecution for LEVIATHAN {
 
         //=======ステップ2===========
         //【Nonceの加算】
-        if state.is_empty(&sender_address) {
+        if state.is_dead(self.version,&sender_address) {
             return Err((U256::ZERO, Vec::new())); //sender_addressが見つからないのは異常
         }
         state.inc_nonce(&sender_address);
@@ -193,7 +193,7 @@ impl TransactionExecution for LEVIATHAN {
                 let return_gas = gas.saturating_add(reimburse);
                 //送信者への返金
                 let reimburse = return_gas.saturating_mul(transaction.t_price);
-                if state.is_empty(&sender_address) {
+                if state.is_dead(self.version, &sender_address) {
                     //add_balance前の確認
                     if !state.is_physically_exist(&sender_address) {
                         state.add_account(&sender_address, Account::new()); //アカウントを追加
@@ -208,7 +208,7 @@ impl TransactionExecution for LEVIATHAN {
                     transaction.t_price - block_header.h_basefee
                 };
                 let reward = final_billed_gas.saturating_mul(f);
-                if state.is_empty(&block_header.h_beneficiary) {
+                if state.is_dead(self.version, &block_header.h_beneficiary) {
                     //add_balance前の確認
                     if !state.is_physically_exist(&block_header.h_beneficiary) {
                         state.add_account(&block_header.h_beneficiary, Account::new()); //アカウントを追加
@@ -324,7 +324,7 @@ impl TransactionExecution for LEVIATHAN {
             Err((gas, _, _)) => {
                 //送信者への返金
                 let reimburse = gas.saturating_mul(transaction.t_price);
-                if state.is_empty(&sender_address) {
+                if state.is_dead(self.version, &sender_address) {
                     //add_balance前の確認
                     if !state.is_physically_exist(&sender_address) {
                         state.add_account(&sender_address, Account::new()); //アカウントを追加
@@ -339,7 +339,7 @@ impl TransactionExecution for LEVIATHAN {
                     transaction.t_price - block_header.h_basefee
                 };
                 let reward = final_billed_gas.saturating_mul(f);
-                if state.is_empty(&block_header.h_beneficiary) {
+                if state.is_dead(self.version, &block_header.h_beneficiary) {
                     //add_balance前の確認
                     if !state.is_physically_exist(&block_header.h_beneficiary) {
                         state.add_account(&block_header.h_beneficiary, Account::new()); //アカウントを追加

--- a/src/leviathan/mpt_method.rs
+++ b/src/leviathan/mpt_method.rs
@@ -24,7 +24,6 @@ impl State for WorldState {
             if account.nonce != 0
                 || !account.balance.is_zero()
                 || account.code.len() != 0
-                || account.storage_hash != EMPTY_STORAGE_ROOT
             {
                 return false;
             }
@@ -46,7 +45,6 @@ impl State for WorldState {
                     if account.nonce != 0
                         || !account.balance.is_zero()
                             || account.code_hash != EMPTY_CODE_HASH
-                            || account.storage_root != EMPTY_STORAGE_ROOT
                             {
                                 return false;
                             }


### PR DESCRIPTION
## 概要
Ethereum Yellow Paperの厳密な定義（式14、式15）および、Spurious Dragonフォーク前後における「State Clearing（アカウント自動削除）」の歴史的仕様に基づき、アカウントの状態判定ロジックを抜本的にリファクタリングした。
冗長かつ誤用の原因となっていた is_empty メソッドの削除と判定ロジックの修正を行い、すべての状態判定をフォークに依存する is_dead メソッドに統合した。

## 課題
EVMのステート管理において、これまで「アカウントが空であるか」を判定する is_empty と、「アカウントが死んでいる（削除対象である）か」を判定する is_dead が混在していた。

### 歴史的仕様の誤認
Spurious Dragonフォーク以前は「そもそもアカウントを自動削除する（State Clearing）」という概念が存在せず、物理的にMPTに存在すればDEADではなかった。Spurious Dragon以降（EIP-161）は、悪意のある「0 Wei送金」によるステート肥大化（上海攻撃）を防ぐため、**「Nonce, Balance, Code の3つが空（EMPTY）であれば、Storageの状態に関わらず強制削除する」**という強力なガベージコレクションが導入された。

### Yellow Paperの定義とのズレ
Yellow Paper上では「DEAD は EMPTY を内包する上位概念（物理的に存在しない、または EMPTY であること）」として定義されている。これまでのコードでは、is_empty 側でストレージの存在チェック（storage_hash != EMPTY_STORAGE_ROOT）が残ってしまっており、特定のフォークにおいてバグの温床となる危険性があった。


## 修正内容
- is_empty内の判定基準からストレージが空かどうかを削除し，アカウントの削除要否などの状態判定をすべて is_dead に踏襲（統合）した。

- is_dead の内部ロジックをフォーク仕様に完全対応させた。
Spurious Dragon以前: 物理的な存在（contains_key や contain_mpt）のみをチェック。
Spurious Dragon以降: Storageのハッシュ状態を完全に無視し、Yellow Paperの EMPTY 定義通り（nonce == 0, balance == 0, code == empty）の3条件のみで判定するよう修正（is_emptyを使用)。

