### PR TITLE
fix(precompile): ecrecoverのガス計算バグ修正およびstSolidityTestの完全突破

### DIFF
--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -610,7 +610,7 @@ mod state_tests {
             .try_init();
 
         // 対象のディレクトリ
-        let test_dir = "MPTTest/stSolidityTest";
+        let test_dir = "MPTTest/stWalletTest";
 
         let paths = std::fs::read_dir(test_dir)
             .unwrap_or_else(|_| panic!("Failed to read test directory: {}", test_dir));

--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -610,7 +610,7 @@ mod state_tests {
             .try_init();
 
         // 対象のディレクトリ
-        let test_dir = "MPTTest/stRevertTest";
+        let test_dir = "MPTTest/stSolidityTest";
 
         let paths = std::fs::read_dir(test_dir)
             .unwrap_or_else(|_| panic!("Failed to read test directory: {}", test_dir));

--- a/src/leviathan/precompile.rs
+++ b/src/leviathan/precompile.rs
@@ -91,7 +91,7 @@ impl CompiledContract for LEVIATHAN {
         let result: [u8; 32] = hasher.finalize().into();
         let mut return_data = vec![0u8; 32];
         return_data[12..].copy_from_slice(&result[12..]);
-        Ok((gas, return_data))
+        Ok((return_gas, return_data))
     }
 
     #[inline(never)]


### PR DESCRIPTION
## 概要
プレコンパイルコントラクト ecrecover (0x01) の実行成功時に、消費ガスが正しく差し引かれず、入力されたガス量がそのまま返却されてしまうバグを修正した。
この修正により、実践的なスマートコントラクトの挙動を検証する stSolidityTest の全テストケースを完全にパスすることに成功した。

## 修正内容

### ecrecoverの戻りガス計算の最適化
プレコンパイルコントラクト ecrecover 内の処理において、実行成功時に返す return_gas を適切な値（入力ガスから ecrecover の規定消費ガスである 3000 gas を差し引いた値）に修正した。

## 結果
- ecrecover を利用するすべてのコントラクト呼び出しにおいて、ガス計算がEthereumの仕様と完全に一致するようになった。
- stSolidityTest を制覇したことにより、Leviathan EVM が実際のDApps等でデプロイされる標準的なSolidityコントラクトを正確に実行・処理できる基盤が完成した。