### PR TITLE
fix: stZeroKnowledge 実行時のPanicを解消 (bn_mul 内のタイポ修正)

### DIFF
--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -634,7 +634,7 @@ mod state_tests {
             .try_init();
 
         // 対象のディレクトリ
-        let test_dir = "MPTTest/stWalletTest";
+        let test_dir = "MPTTest/stZeroKnowledge";
 
         let paths = std::fs::read_dir(test_dir)
             .unwrap_or_else(|_| panic!("Failed to read test directory: {}", test_dir));

--- a/src/leviathan/precompile.rs
+++ b/src/leviathan/precompile.rs
@@ -447,7 +447,7 @@ impl CompiledContract for LEVIATHAN {
         }
         let result_bytes_x = p_result_affine.x.into_bigint().to_bytes_be();
         let result_bytes_y = p_result_affine.y.into_bigint().to_bytes_be();
-        let mut tmp = vec![0u8, 64];
+        let mut tmp = vec![0u8; 64];
         tmp[32 - result_bytes_x.len()..32].copy_from_slice(&result_bytes_x[..]);
         tmp[64 - result_bytes_y.len()..64].copy_from_slice(&result_bytes_y[..]);
 


### PR DESCRIPTION
## 概要
Ethereum StateTestの stZeroKnowledge テストスイート実行中に発生していたPanicを修正した．

## 原因
bn_mul 関数内のバッファ（配列）初期化部分にタイポがありました。
Rustの構文として、要素数指定にはセミコロン（;）を用いる必要がありますが、カンマ（,）になっていた。

- 誤: [0u8, 64] （0 と 64 を持つ要素数2の配列として推論される）
- 正: [0u8; 64] （0 で初期化された要素数64の配列）

この配列サイズの不一致が原因で、メモリ操作時やスライスの参照時に意図しないPanicの引き金となっていた．

## 結果
stZeroKnowledge 関連のテストケースがPanicせずに正常に進行するようになった．