### PR TITLE
styling: cargo fmt

### DIFF
--- a/src/leviathan/call.rs
+++ b/src/leviathan/call.rs
@@ -13,13 +13,13 @@ use alloy_primitives::{Address, U256};
 use sha3::Digest;
 
 //cpu実行時間を記録するため
+use alloy_primitives::hex;
 #[cfg(test)]
 use std::fs::OpenOptions;
 #[cfg(test)]
 use std::io::Write;
 #[cfg(test)]
 use std::time::Instant;
-use alloy_primitives::hex;
 
 impl MessageCall for LEVIATHAN {
     fn message_call(
@@ -194,40 +194,40 @@ impl MessageCall for LEVIATHAN {
                 }
             }
         };
-        
+
         /*/ ★ 2. CSVへの記録処理 (テスト時のみコンパイル)
-#[cfg(test)]
-        {
-            if let Some(start) = start_time {
-                let elapsed_micros = start.elapsed().as_micros();
-                // データの「中身」ではなく「長さ」だけ取得
-                let input_len = execution_environment.i_data.len();
+        #[cfg(test)]
+                {
+                    if let Some(start) = start_time {
+                        let elapsed_micros = start.elapsed().as_micros();
+                        // データの「中身」ではなく「長さ」だけ取得
+                        let input_len = execution_environment.i_data.len();
 
-                let (status, consumed_gas) = match &result {
-                    Ok((rest_gas, _)) => {
-                        ("Success", gas.saturating_sub(*rest_gas))
+                        let (status, consumed_gas) = match &result {
+                            Ok((rest_gas, _)) => {
+                                ("Success", gas.saturating_sub(*rest_gas))
+                            }
+                            Err((rest_gas, _)) => {
+                                ("Revert_or_Error", gas.saturating_sub(*rest_gas))
+                            }
+                        };
+
+                        // InputData(Hex) を InputLen に差し替え
+                        let csv_line = format!(
+                            "{},{},{},{},{}\n",
+                            contract_u256, input_len, consumed_gas, status, elapsed_micros
+                            );
+
+                        if let Ok(mut file) = OpenOptions::new()
+                            .create(true)
+                                .append(true)
+                                .open("gas_analy/stRevertTest_benchmarks.csv")
+                                {
+                                    let _ = file.write_all(csv_line.as_bytes());
+                                }
                     }
-                    Err((rest_gas, _)) => {
-                        ("Revert_or_Error", gas.saturating_sub(*rest_gas))
-                    }
-                };
-
-                // InputData(Hex) を InputLen に差し替え
-                let csv_line = format!(
-                    "{},{},{},{},{}\n",
-                    contract_u256, input_len, consumed_gas, status, elapsed_micros
-                    );
-
-                if let Ok(mut file) = OpenOptions::new()
-                    .create(true)
-                        .append(true)
-                        .open("gas_analy/stRevertTest_benchmarks.csv")
-                        {
-                            let _ = file.write_all(csv_line.as_bytes());
-                        }
-            }
-        }
-        */
+                }
+                */
         match result {
             Ok((return_gas, output)) => {
                 //最終処理

--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -470,4 +470,3 @@ impl TransactionExecution for LEVIATHAN {
         }
     }
 }
-

--- a/src/leviathan/precompile.rs
+++ b/src/leviathan/precompile.rs
@@ -10,12 +10,12 @@ use ark_ec::{AffineRepr, CurveGroup};
 use ark_ff::{BigInteger, One, PrimeField, Zero};
 use num_bigint::BigUint;
 use ripemd::{Digest as _, Ripemd160};
+use rsa::{Pkcs1v15Sign, RsaPublicKey};
 use secp256k1::Secp256k1;
 use sha2::{Digest as _, Sha256};
 use sha3::{Digest as _, Keccak256};
 use std::ops::Mul;
 use std::ops::Rem;
-use rsa::{RsaPublicKey, Pkcs1v15Sign};
 
 pub const SECP256K1N: U256 =
     uint!(0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141_U256);
@@ -569,7 +569,6 @@ impl CompiledContract for LEVIATHAN {
         Ok((return_gas, output))
     }
 
-
     fn my_rsa(
         gas: U256,
         data: &[u8],
@@ -590,7 +589,7 @@ impl CompiledContract for LEVIATHAN {
             tracing::warn!("[my_rsa] 入力データが不適切");
             return Err((U256::ZERO, None));
         }
-            
+
         //使用ガス量を計算
         let gas_required = U256::from(168000);
         // Out-of-Gas (OOG) 検証
@@ -609,14 +608,16 @@ impl CompiledContract for LEVIATHAN {
         let n = rsa::BigUint::from_bytes_be(&modulus_byte);
         let e = rsa::BigUint::from_bytes_be(&exponent_byte);
 
-        let Ok(public_key) = RsaPublicKey::new(n,e) else{
+        let Ok(public_key) = RsaPublicKey::new(n, e) else {
             tracing::warn!("[my_rsa] RsaPublicKey生成失敗");
             return Err((U256::ZERO, None));
         };
 
         // 4. PKCS#1 v1.5 による署名検証
         let scheme = Pkcs1v15Sign::new::<Sha256>();
-        let is_valid = public_key.verify(scheme, &message_byte, &signature_byte).is_ok();
+        let is_valid = public_key
+            .verify(scheme, &message_byte, &signature_byte)
+            .is_ok();
         let mut output = vec![0u8; 32];
         if is_valid {
             output[31] = 1;
@@ -624,5 +625,4 @@ impl CompiledContract for LEVIATHAN {
 
         Ok((return_gas, output))
     }
-
 }

--- a/src/leviathan/world_state.rs
+++ b/src/leviathan/world_state.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use alloy_primitives::{Address, B256, U256, b256, keccak256, hex};
+use alloy_primitives::{Address, B256, U256, b256, hex, keccak256};
 use alloy_rlp::{Decodable, Encodable, RlpDecodable, RlpEncodable};
 use eth_trie::{EthTrie, MemoryDB, Trie};
 use sha3::Digest;
@@ -44,14 +44,14 @@ impl WorldState {
     pub fn init_mpt_account(&mut self, address: &Address, cache_account: &Account) {
         let mpt_nonce = cache_account.nonce;
         let mpt_balance = cache_account.balance;
-        let mut storage_trie = EthTrie::from(self.data.clone(), cache_account.storage_hash).unwrap();
+        let mut storage_trie =
+            EthTrie::from(self.data.clone(), cache_account.storage_hash).unwrap();
         let mut storage_changed = false;
         //storageの値を書き込む
         for (key, value) in cache_account.storage.iter() {
             let key_byte: [u8; 32] = key.to_be_bytes();
             let key_hash = keccak256(key_byte);
-            let existing_val_opt =
-                storage_trie.get(key_hash.as_slice()).unwrap_or(None);
+            let existing_val_opt = storage_trie.get(key_hash.as_slice()).unwrap_or(None);
 
             if value.is_zero() {
                 if existing_val_opt.is_some() {
@@ -76,8 +76,7 @@ impl WorldState {
         };
         //コードハッシュを取得
         let code_hash = keccak256(cache_account.code.clone());
-        self
-            .code_storage
+        self.code_storage
             .entry(code_hash)
             .or_insert(cache_account.code.clone());
         //mpt_accout作成
@@ -86,15 +85,14 @@ impl WorldState {
             cache_account.balance,
             storage_root,
             code_hash,
-            );
+        );
         //MPTに書き込む
         let address_hash = keccak256(address);
         let mut mpt_account_rlp_bytes = Vec::new();
         mpt_account.encode(&mut mpt_account_rlp_bytes);
 
         //MPTに現在登録されているRLPを取得
-        let existing_mpt_val =
-            self.eth_trie.get(address_hash.as_slice()).unwrap_or(None);
+        let existing_mpt_val = self.eth_trie.get(address_hash.as_slice()).unwrap_or(None);
 
         // 更新すべきか判定
         let should_insert = match existing_mpt_val {
@@ -109,8 +107,7 @@ impl WorldState {
         if should_insert {
             tracing::debug!("更新: 0x{}", hex::encode(address));
             let _ = self.eth_trie.remove(address_hash.as_slice());
-            self
-                .eth_trie
+            self.eth_trie
                 .insert(address_hash.as_slice(), mpt_account_rlp_bytes.as_slice())
                 .unwrap();
         }
@@ -118,8 +115,6 @@ impl WorldState {
         let new_state_root = self.eth_trie.root_hash().unwrap();
         self.update_eth_trie(new_state_root);
     }
-
-
 
     pub fn add_cache(&mut self, address: &Address, mpt_account: &MptAccount) {
         let nonce = mpt_account.nonce;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,18 +4,18 @@ pub mod leviathan;
 pub mod my_trait;
 pub mod test;
 
-use alloy_primitives::{Address, U256, hex, keccak256, uint, Bytes};
-use rsa::{RsaPrivateKey, RsaPublicKey, pkcs1v15::Pkcs1v15Sign, traits::PublicKeyParts};
-use sha2::{Digest as _, Sha256};
-use rand::rngs::OsRng;
-use secp256k1::{Secp256k1, SecretKey, Message};
+use alloy_primitives::{Address, Bytes, U256, hex, keccak256, uint};
 use alloy_rlp::{Encodable, Header};
 use bytes::BytesMut;
+use rand::rngs::OsRng;
+use rsa::{RsaPrivateKey, RsaPublicKey, pkcs1v15::Pkcs1v15Sign, traits::PublicKeyParts};
+use secp256k1::{Message, Secp256k1, SecretKey};
+use sha2::{Digest as _, Sha256};
 
+use leviathan::leviathan::LEVIATHAN;
 use leviathan::structs::{BlockHeader, Transaction, VersionId};
 use leviathan::world_state::{Account, WorldState};
-use leviathan::leviathan::LEVIATHAN;
-use my_trait::leviathan_trait::{TransactionExecution, State};
+use my_trait::leviathan_trait::{State, TransactionExecution};
 
 /// イエローペーパー Appendix F に基づくトランザクション署名関数
 fn sign_tx_properly(
@@ -40,7 +40,11 @@ fn sign_tx_properly(
     payload_length += data.length();
 
     let mut out = BytesMut::with_capacity(payload_length + 10);
-    Header { list: true, payload_length }.encode(&mut out);
+    Header {
+        list: true,
+        payload_length,
+    }
+    .encode(&mut out);
 
     nonce.encode(&mut out);
     gas_price.encode(&mut out);
@@ -68,7 +72,7 @@ fn main() {
     // ログレベルを指定して詳細な動きを追えるようにします
     let _ = tracing_subscriber::fmt::init();
     let version = VersionId::Petersburg;
-    
+
     // 前回の完璧なアーキテクチャ修正が活きる WorldState の初期化！
     let mut state = WorldState::new();
     let mut leviathan = LEVIATHAN::new(version);
@@ -77,7 +81,10 @@ fn main() {
     // ---------------------------------------------------------
     // 1. 送信者 (EOA) の準備
     // ---------------------------------------------------------
-    let secret_key = SecretKey::from_slice(&hex!("45cd63531c3c97355b9275e7a9e6323c2a937a07011d8825e36873c907b29a28")).unwrap();
+    let secret_key = SecretKey::from_slice(&hex!(
+        "45cd63531c3c97355b9275e7a9e6323c2a937a07011d8825e36873c907b29a28"
+    ))
+    .unwrap();
     let public_key = secp256k1::PublicKey::from_secret_key(&secp, &secret_key);
     let serialized_pub = public_key.serialize_uncompressed();
     let pub_hash = keccak256(&serialized_pub[1..65]);
@@ -85,7 +92,7 @@ fn main() {
 
     let mut sender_acc = Account::new();
     sender_acc.balance = uint!(100_000_000_000_000_000_000_U256); // 100 ETH
-    
+
     // 自作した完璧な init_mpt_account メソッドで安全に状態を構築
     state.init_mpt_account(&sender_addr, &sender_acc);
 
@@ -97,18 +104,21 @@ fn main() {
     let priv_key = RsaPrivateKey::new(&mut OsRng, 2048).unwrap();
     let pub_key = RsaPublicKey::from(&priv_key);
     let msg_hash = keccak256("Leviathan Vote");
-    let signature = priv_key.sign(Pkcs1v15Sign::new::<Sha256>(), msg_hash.as_slice()).unwrap();
+    let signature = priv_key
+        .sign(Pkcs1v15Sign::new::<Sha256>(), msg_hash.as_slice())
+        .unwrap();
 
     // ---------------------------------------------------------
     // 3. ペイロードデータの構築（Solidityの忖度なし！生データ直結！）
     // ---------------------------------------------------------
     // 関数セレクタもオフセットパディングも不要。純粋なデータを連結するだけ。
     let payload_data = [
-        signature.as_slice(),         // 256 bytes
-        &pub_key.n().to_bytes_be(),   // 256 bytes
-        msg_hash.as_slice(),          // 32 bytes
-        &pub_key.e().to_bytes_be()    // 可変長
-    ].concat();
+        signature.as_slice(),       // 256 bytes
+        &pub_key.n().to_bytes_be(), // 256 bytes
+        msg_hash.as_slice(),        // 32 bytes
+        &pub_key.e().to_bytes_be(), // 可変長
+    ]
+    .concat();
 
     // ---------------------------------------------------------
     // 4. トランザクションの構築と正当な署名
@@ -127,8 +137,8 @@ fn main() {
         t_gas_limit,
         Some(precompile_addr), // ここで 0x0a を指定！
         t_value,
-        &payload_data,         // 生データをそのまま送信
-        &secret_key
+        &payload_data, // 生データをそのまま送信
+        &secret_key,
     );
 
     let transaction = Transaction {
@@ -157,7 +167,10 @@ fn main() {
 
     println!("🚀 Starting Direct EVM Execution to RSA Precompile (0x0a)...");
     match leviathan.execution(&mut state, transaction, &block) {
-        Ok((gas, _)) => println!("✅ Success! Precompile verified the signature. Remaining Gas: {}", gas),
+        Ok((gas, _)) => println!(
+            "✅ Success! Precompile verified the signature. Remaining Gas: {}",
+            gas
+        ),
         Err((gas, _)) => println!("❌ Failed. Precompile call reverted. Gas consumed: {}", gas),
     }
 }

--- a/tests/bench_runner.rs
+++ b/tests/bench_runner.rs
@@ -1,15 +1,15 @@
 use alloy_primitives::{U256, hex, keccak256};
-use leviathan_v2::leviathan::structs::VersionId;
 use leviathan_v2::leviathan::leviathan::LEVIATHAN;
+use leviathan_v2::leviathan::structs::VersionId;
 use leviathan_v2::my_trait::leviathan_trait::CompiledContract;
-use std::time::Instant;
 use std::fs::OpenOptions;
 use std::io::Write;
+use std::time::Instant;
 
 // RSA生成用のクレート（main.rs で使用しているものと同じ）
+use rand::rngs::OsRng;
 use rsa::{RsaPrivateKey, RsaPublicKey, pkcs1v15::Pkcs1v15Sign, traits::PublicKeyParts};
 use sha2::Sha256;
-use rand::rngs::OsRng;
 
 #[test]
 fn benchmark_rsa_precompile() {
@@ -71,7 +71,9 @@ fn benchmark_rsa_precompile() {
 
     let csv_line = format!(
         "PayloadLen:{},Status:{},Time_us:{}\n",
-        payload.len(), status, elapsed_us
+        payload.len(),
+        status,
+        elapsed_us
     );
     file.write_all(csv_line.as_bytes()).unwrap();
 
@@ -80,4 +82,3 @@ fn benchmark_rsa_precompile() {
     println!("   Execution Time: {} us", elapsed_us);
     println!("   Status       : {}", status);
 }
-

--- a/tests/state_runner.rs
+++ b/tests/state_runner.rs
@@ -3,21 +3,21 @@ use std::fs;
 use std::io::Write;
 
 // alloy_primitives の hex を使用して E0433 を解消
-use alloy_primitives::{Address, U256, hex,keccak256};
+use alloy_primitives::{Address, U256, hex, keccak256};
 
 // 署名生成のためのクレート
 use alloy_rlp::{Encodable, Header};
 use bytes::BytesMut;
+use eth_trie::{EthTrie, Trie};
 use secp256k1::{Message, Secp256k1, SecretKey};
 use sha3::{Digest, Keccak256};
-use eth_trie::{EthTrie, Trie};
 
 // 🌟 crate:: ではなく パッケージ名 (ここでは leviathan_v2 と仮定) を使用します
-use leviathan_v2::test::state_parser::{IndexType, StateTestSuite};
-use leviathan_v2::leviathan::structs::{BlockHeader, Transaction, VersionId};
-use leviathan_v2::leviathan::world_state::{Account, WorldState, MptAccount}; // MptAccount を追加
 use leviathan_v2::leviathan::leviathan::LEVIATHAN; // LEVIATHAN を追加
-use leviathan_v2::my_trait::leviathan_trait::{TransactionExecution, State};
+use leviathan_v2::leviathan::structs::{BlockHeader, Transaction, VersionId};
+use leviathan_v2::leviathan::world_state::{Account, MptAccount, WorldState}; // MptAccount を追加
+use leviathan_v2::my_trait::leviathan_trait::{State, TransactionExecution};
+use leviathan_v2::test::state_parser::{IndexType, StateTestSuite};
 
 // --- ヘルパー関数 ---
 
@@ -97,7 +97,7 @@ fn sign_transaction(
     value: U256,
     data: &[u8],
     secret_key_hex: &str,
-    ) -> (U256, U256, U256) {
+) -> (U256, U256, U256) {
     // 1. 各要素のRLPペイロード長を事前計算する
     let mut payload_length = 0;
     payload_length += nonce.length();
@@ -170,7 +170,7 @@ fn state_test() {
 
     // 対象のディレクトリ
     let test_dirs = vec![
-        "TestData/MPTTest/stAttackTest", 
+        "TestData/MPTTest/stAttackTest",
         "TestData/MPTTest/stBadOpcode",
         "TestData/MPTTest/stBugs",
         "TestData/MPTTest/stCallCodes",
@@ -204,8 +204,7 @@ fn state_test() {
         "TestData/MPTTest/stZeroCallsRevert",
         "TestData/MPTTest/stZeroCallsTest",
         "TestData/MPTTest/stZeroKnowledge",
-        ];
-
+    ];
 
     let mut total_files = 0;
     let mut pass_cases_count = 0;
@@ -216,7 +215,10 @@ fn state_test() {
         let paths = match std::fs::read_dir(test_dir) {
             Ok(p) => p,
             Err(e) => {
-                println!("Failed to read directory '{}': {}. Skipping...", test_dir, e);
+                println!(
+                    "Failed to read directory '{}': {}. Skipping...",
+                    test_dir, e
+                );
                 continue;
             }
         };
@@ -302,7 +304,7 @@ fn state_test() {
                                     println!(
                                         "  [Network: {:<17}] Matrix {} (data: {}, gas: {}, value: {})",
                                         network_str, post_idx, data_idx, gas_idx, value_idx
-                                        );
+                                    );
 
                                     // 1. WorldStateの初期化 (必ず毎ループ初期化する！)
                                     let mut state = WorldState::new();
@@ -327,7 +329,7 @@ fn state_test() {
                                                         .insert(
                                                             key_hash.as_slice(),
                                                             val_rlp.as_slice(),
-                                                            )
+                                                        )
                                                         .unwrap();
                                                 }
                                             }
@@ -371,7 +373,7 @@ fn state_test() {
                                             balance,
                                             initial_storage_root,
                                             code_hash,
-                                            );
+                                        );
                                         let addr_hash = keccak256(&addr);
                                         let mut mpt_rlp = Vec::new();
                                         mpt_account.encode(&mut mpt_rlp);
@@ -385,19 +387,19 @@ fn state_test() {
                                     println!(
                                         "    [Pre-State] Initial State Root: {}",
                                         pre_state_root
-                                        );
+                                    );
 
                                     // --- ここから下が Env情報の構築 と トランザクション実行 (leviathan.execution) ---
 
                                     let block_header = BlockHeader {
                                         h_beneficiary: parse_address(
-                                                           &test_data.env.current_coinbase,
-                                                           ),
-                                                           h_timestamp: parse_u256(&test_data.env.current_timestamp),
-                                                           h_number: parse_u256(&test_data.env.current_number),
-                                                           h_prevrandao: parse_u256(&test_data.env.current_difficulty),
-                                                           h_gaslimit: parse_u256(&test_data.env.current_gas_limit),
-                                                           h_basefee: U256::ZERO,
+                                            &test_data.env.current_coinbase,
+                                        ),
+                                        h_timestamp: parse_u256(&test_data.env.current_timestamp),
+                                        h_number: parse_u256(&test_data.env.current_number),
+                                        h_prevrandao: parse_u256(&test_data.env.current_difficulty),
+                                        h_gaslimit: parse_u256(&test_data.env.current_gas_limit),
+                                        h_basefee: U256::ZERO,
                                     };
 
                                     let tx_data = parse_code(tx_data_str);
@@ -421,7 +423,7 @@ fn state_test() {
                                         value,
                                         &tx_data,
                                         secret_key_hex,
-                                        );
+                                    );
 
                                     let transaction = Transaction {
                                         data: tx_data,
@@ -452,7 +454,7 @@ fn state_test() {
                                         println!(
                                             "    => Success! State Root Matches: {}",
                                             expected_hash
-                                            );
+                                        );
                                         pass_cases_count += 1;
                                     } else {
                                         println!("    => FAILED!");
@@ -460,18 +462,18 @@ fn state_test() {
                                         println!("       Actual  : {}", actual_hash);
                                         println!(
                                             "\n=== 🔍 最終ステートのダンプ (Cache内の最新状態) ==="
-                                            );
+                                        );
                                         for (address, account) in &state.cache {
                                             println!(
                                                 "Address: 0x{}",
                                                 alloy_primitives::hex::encode(address.0)
-                                                );
+                                            );
                                             println!("  Nonce       : {}", account.nonce);
                                             println!("  Balance     : {}", account.balance);
                                             println!(
                                                 "  Code (len)  : {} bytes",
                                                 account.code.len()
-                                                );
+                                            );
                                             println!("  Storage:");
                                             if account.storage.is_empty() {
                                                 println!("    (empty)");
@@ -487,16 +489,16 @@ fn state_test() {
                                             println!("  StorageRoot : {}", account.storage_hash);
                                             println!(
                                                 "---------------------------------------------------"
-                                                );
+                                            );
                                         }
                                         println!(
                                             "===================================================\n"
-                                            );
+                                        );
                                         assert_eq!(
                                             actual_hash, expected_hash,
                                             "State root mismatch in test: {}",
                                             test_name
-                                            );
+                                        );
                                     }
                                 }
                             }
@@ -510,6 +512,6 @@ fn state_test() {
     println!(
         "最終結果: {} ファイル中、{} / {} のテストケースをクリアしました！",
         total_files, pass_cases_count, total_cases_count
-        );
+    );
     println!("==================================================\n");
 }


### PR DESCRIPTION
## 概要（What）
GitHub ActionsのCIパイプライン（`test-and-lint`）において発生していたビルドエラーを解消するため、コードベース全体に `cargo fmt` を実行し、Rustの標準スタイルに合わせてフォーマットを修正した。

## 背景・課題（Why）
現在設定されている `.github/workflows/ci.yml` では、静的解析のステップとして `cargo fmt --all -- --check` が実行されるようになっている。この `--check` オプションは、コード内にインデントのズレや不要な空白などのフォーマット違反が1つでも存在する場合、コンパイルの成否に関わらず `exit code 1` を返してCIプロセスを強制終了させる仕様である。
最近のコミットにおいてフォーマットの乱れが含まれていたため、テスト実行のステップに到達する前にCIがフェイル（失敗）してしまう状態となっていた。

## 詳細な修正内容（How）
* ローカル環境にて `cargo fmt` を実行し、全ファイルのフォーマットを自動整形した。
* 本PRを作成することで、`pull_request` トリガーによってCIを起動し、フォーマットチェックおよび後続の `cargo clippy`、`cargo test` が正常に通過することを検証する。
