### PR TITLE
[Fix] プレコンパイルコントラクトにおける脆弱性の修正およびロジックの堅牢化 (expmod, sha256等)

### DIFF
--- a/src/leviathan/precompile.rs
+++ b/src/leviathan/precompile.rs
@@ -100,7 +100,7 @@ impl CompiledContract for LEVIATHAN {
         // 1. 必要ガスの計算: 60 + 12 * ceil(|data| / 32)
         // 整数演算での切り上げ: (len + 31) / 32
         let word_count = data.len().div_ceil(32);
-        let gas_required = U256::from(60) + U256::from(12 * word_count);
+        let gas_required = U256::from(60) + (U256::from(12) * U256::from(word_count));
 
         // 2. Out-of-Gas (OOG) 検証
         if gas < gas_required {
@@ -125,7 +125,7 @@ impl CompiledContract for LEVIATHAN {
     ) -> Result<(U256, Vec<u8>), (U256, Option<Vec<u8>>)> {
         // 1. 必要ガスの計算: 600 + 120 * ceil(|data| / 32) [cite: 1388]
         let word_count = data.len().div_ceil(32);
-        let gas_required = U256::from(600) + U256::from(120 * word_count);
+        let gas_required = U256::from(600) + (U256::from(120) * U256::from(word_count));
 
         // 2. Out-of-Gas (OOG) 検証
         if gas < gas_required {
@@ -158,7 +158,7 @@ impl CompiledContract for LEVIATHAN {
     ) -> Result<(U256, Vec<u8>), (U256, Option<Vec<u8>>)> {
         // 1. 必要ガスの計算: 15 + 3 * ceil(|data| / 32) [cite: 1397]
         let word_count = data.len().div_ceil(32);
-        let gas_required = U256::from(15) + U256::from(3 * word_count);
+        let gas_required = U256::from(15) + (U256::from(3) * U256::from(word_count));
 
         // 2. Out-of-Gas (OOG) 検証
         if gas < gas_required {

--- a/src/leviathan/precompile.rs
+++ b/src/leviathan/precompile.rs
@@ -224,8 +224,8 @@ impl CompiledContract for LEVIATHAN {
         //val2
         let val2 = if e_len <= U256::from(32) {
             let e_len_usize = e_len.try_into().unwrap_or(0);
-            let b_len_usize = e_len.try_into().unwrap_or(usize::MAX);
-            let e_bytes = get_padded_data(96 + b_len_usize, e_len_usize);
+            let b_len_usize = b_len.try_into().unwrap_or(usize::MAX);
+            let e_bytes = get_padded_data(b_len_usize.saturating_add(96), e_len_usize);
             let e_val_u256 = U256::from_be_slice(&e_bytes);
             if e_val_u256.is_zero() {
                 U256::from(1)
@@ -234,8 +234,8 @@ impl CompiledContract for LEVIATHAN {
             }
         } else {
             let _e_len_usize = e_len.try_into().unwrap_or(0);
-            let b_len_usize = e_len.try_into().unwrap_or(usize::MAX);
-            let e_top_bytes = get_padded_data(96 + b_len_usize, 32);
+            let b_len_usize = b_len.try_into().unwrap_or(usize::MAX);
+            let e_top_bytes = get_padded_data(b_len_usize.saturating_add(96), 32);
             let e_top = U256::from_be_slice(&e_top_bytes);
             let rest = e_len - U256::from(32);
 


### PR DESCRIPTION
## 概要
本PRでは、`CompiledContract` に実装されている各種プレコンパイルコントラクトにおいて発見された、致命的なバグおよび潜在的な整数のオーバーフロー脆弱性を修正しました。
これらの修正により、不正な入力データによるノードのパニック（DoS攻撃）を防止し、Ethereum Yellow Paperの仕様に基づいたより安全な実行環境を提供します。

## 変更内容

### `expmod` (0x05) におけるDoS脆弱性と論理バグの修正
- **変数定義の誤り修正:** `b_len_usize`（Baseの長さ）を算出する際に、誤って `e_len`（Exponentの長さ）を参照していたコピペミスを修正しました。
- **整数オーバーフロー対策:** メモリオフセットの計算 `b_len_usize + 96` において、`b_len_usize` が巨大な値の場合に `usize` がオーバーフローしてノードがパニックする危険がありました。これを `saturating_add` に置き換え、安全に境界を管理するように変更しました。

### 標準プレコンパイル群のガス代算出ロジックの堅牢化
対象: `sha256` (0x02), `ripemd160` (0x03), `identity` (0x04)
- **乗算オーバーフローの防止:** 従来の計算式 `12 * word_count` では、`U256` に変換される前に `usize` の範囲内で掛け算が行われていました。32ビット環境や極端に巨大なデータ入力時にオーバーフローが発生し、不当に安いガス代で計算を通過させるリスクがありました。
- **修正後:** すべての項を先に `U256` 型へキャストしてから計算を行うことで、EVMのワードサイズに基づいた安全なガス計算を保証します。

## 修正詳細（コードビフォーアフター）

#### ガス計算の修正例 (`sha256`)
- **[Before]**: `let gas_required = U256::from(60) + U256::from(12 * word_count);`
- **[After]**: `let gas_required = U256::from(60) + (U256::from(12) * U256::from(word_count));`

#### `expmod` のオフセット計算
- **[Before]**: `let e_bytes = get_padded_data(96 + b_len_usize, e_len_usize);`
- **[After]**: `let e_bytes = get_padded_data(b_len_usize.saturating_add(96), e_len_usize)`

## テスト結果
- [x] `state_runner` における既存のテストセットがすべて正常に通過（回帰テスト完了）。

## 備考
今回修正した `usize` のオーバーフローや型キャストのタイミングは、低レイヤーのシステムプログラミングにおいて脆弱性に直結する重要なポイントです。本修正により、Leviathan EVMの堅牢性がさらに一段階向上しました。