### PR TITLE
refactor: Transactionの宛先(t_to)をTxKindへ移行し、RLP自動デコードの仕様不一致を解消

### DIFF
--- a/gas_analy/rsa_benchmarks.csv
+++ b/gas_analy/rsa_benchmarks.csv
@@ -10,3 +10,4 @@ PayloadLen:547,Status:Success,Time_us:154
 PayloadLen:547,Status:Success,Time_us:170
 PayloadLen:547,Status:Success,Time_us:171
 PayloadLen:547,Status:Success,Time_us:3368
+PayloadLen:547,Status:Success,Time_us:193

--- a/src/bin/abci_node/main.rs
+++ b/src/bin/abci_node/main.rs
@@ -1,20 +1,19 @@
 mod tx_check;
 
+use std::sync::Arc;
+use std::sync::Mutex;
 use tendermint_abci::{Application, ServerBuilder};
 use tendermint_proto::abci::{
     ExecTxResult, RequestCheckTx, RequestFinalizeBlock, RequestInfo, ResponseCheckTx,
     ResponseCommit, ResponseFinalizeBlock, ResponseInfo,
 };
-use tracing::{info, Level};
-use std::sync::Arc;
-use std::sync::Mutex;
+use tracing::{Level, info};
 
 //自作構造体
 use leviathan_v2::leviathan::leviathan::LEVIATHAN;
 use leviathan_v2::leviathan::structs::VersionId;
 use leviathan_v2::leviathan::world_state::{Account, WorldState};
 use tx_check::Tx_Checker;
-
 
 #[derive(Clone)]
 struct LeviathanApp {
@@ -32,7 +31,6 @@ impl LeviathanApp {
         }
     }
 }
-
 
 impl Application for LeviathanApp {
     /// 1. Info: CometBFT起動時に呼ばれる状態同期
@@ -58,16 +56,23 @@ impl Application for LeviathanApp {
 
     /// 3. FinalizeBlock: ブロックの実行とStateRootの計算 (旧 DeliverTx + Begin/EndBlock)
     fn finalize_block(&self, req: RequestFinalizeBlock) -> ResponseFinalizeBlock {
-        info!("[FINALIZE_BLOCK] ブロック生成開始: {} 個のTXが含まれています", req.txs.len());
-        
+        info!(
+            "[FINALIZE_BLOCK] ブロック生成開始: {} 個のTXが含まれています",
+            req.txs.len()
+        );
+
         // ブロック内の各トランザクションに対する実行結果（すべて成功として返す）
-        let tx_results = req.txs.iter().map(|tx| {
-            info!("   - TX実行: {} bytes", tx.len());
-            ExecTxResult {
-                code: 0, // 0 = 実行成功
-                ..Default::default()
-            }
-        }).collect();
+        let tx_results = req
+            .txs
+            .iter()
+            .map(|tx| {
+                info!("   - TX実行: {} bytes", tx.len());
+                ExecTxResult {
+                    code: 0, // 0 = 実行成功
+                    ..Default::default()
+                }
+            })
+            .collect();
 
         // 実行完了後のStateRoot（AppHash）は、このメソッドで返す仕様に変更されました
         let dummy_app_hash = vec![0u8; 32];
@@ -82,9 +87,7 @@ impl Application for LeviathanApp {
     /// 4. Commit: 状態の永続化シグナル
     fn commit(&self) -> ResponseCommit {
         info!("[COMMIT] ブロックのステートを確定しました");
-        ResponseCommit {
-            retain_height: 0,
-        }
+        ResponseCommit { retain_height: 0 }
     }
 }
 
@@ -94,7 +97,7 @@ fn main() {
     info!("Leviathan ABCI Mock Serverを起動中...");
 
     let app = LeviathanApp::new(VersionId::Constantinople);
-    
+
     let server = ServerBuilder::default()
         .bind("127.0.0.1:26658", app)
         .expect("サーバーのバインドに失敗しました");

--- a/src/bin/abci_node/tx_check.rs
+++ b/src/bin/abci_node/tx_check.rs
@@ -1,11 +1,11 @@
 use crate::LeviathanApp;
+use alloy_primitives::{Address, TxKind, U256};
+use alloy_rlp::{Encodable, Header};
+use bytes::BytesMut;
 use leviathan_v2::leviathan::leviathan::LEVIATHAN;
 use leviathan_v2::leviathan::structs::{Transaction, VersionId};
 use leviathan_v2::leviathan::world_state::WorldState;
 use leviathan_v2::my_trait::leviathan_trait::{State, TransactionChecks};
-use alloy_primitives::{Address, U256};
-use alloy_rlp::{Encodable, Header};
-use bytes::BytesMut;
 use secp256k1::{
     Message, Secp256k1,
     ecdsa::{RecoverableSignature, RecoveryId},
@@ -17,10 +17,7 @@ pub trait Tx_Checker {
 }
 
 impl Tx_Checker for LeviathanApp {
-    fn validate_transaction(
-        &mut self,
-        transaction: &Transaction,
-        ) -> bool {
+    fn validate_transaction(&mut self, transaction: &Transaction) -> bool {
         //=======ステップ1===========
         //【初期ガスの計算】
         let base_gas = U256::from(21000); //基本料金
@@ -50,7 +47,7 @@ impl Tx_Checker for LeviathanApp {
         }
 
         let mut contract_gas = U256::ZERO;
-        if transaction.t_to.is_none() {
+        if transaction.t_to.is_create() {
             //コントラクト作成追加費
             if self.version >= VersionId::Homestead {
                 //Homestead以降
@@ -78,8 +75,8 @@ impl Tx_Checker for LeviathanApp {
         payload_length += transaction.t_gas_limit.length();
 
         let to_slice = match &transaction.t_to {
-            Some(address) => address.0.as_slice(),
-            None => &[], // 空のバイト列
+            TxKind::Call(address) => address.0.as_slice(),
+            TxKind::Create => &[], // 空のバイト列
         };
         payload_length += to_slice.length();
         payload_length += transaction.t_value.length();
@@ -176,7 +173,7 @@ impl Tx_Checker for LeviathanApp {
         //Initコードが49152バイト以下
         if self.version >= VersionId::Shanghai {
             //Shanghai以降
-            if transaction.t_to.is_none() && transaction.data.len() > 49152 {
+            if transaction.t_to.is_create() && transaction.data.len() > 49152 {
                 tracing::warn!("Initコードが49152バイトを超えている");
                 return false;
             }

--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -8,7 +8,7 @@ use crate::leviathan::world_state::{Account, MptAccount, WorldState};
 use crate::my_trait::leviathan_trait::{
     ContractCreation, MessageCall, State, TransactionChecks, TransactionExecution,
 };
-use alloy_primitives::{Address, U256, hex, keccak256, TxKind};
+use alloy_primitives::{Address, TxKind, U256, hex, keccak256};
 use alloy_rlp::Encodable;
 use eth_trie::{EthTrie, Trie};
 use sha3::Digest;
@@ -130,13 +130,13 @@ impl TransactionExecution for LEVIATHAN {
             TxKind::Create => {
                 //デバック出力
                 tracing::info!(
-                    sender_address =  format_args!("0x{}", hex::encode(sender_address.0)),
-                    data = %hex::encode(&transaction.data),
-                    gas = %gas,
-                    gas_price = %transaction.t_price,
-                    send_eth = %transaction.t_value,
-                    "Transaction [CREATE]"
-                    );
+                sender_address =  format_args!("0x{}", hex::encode(sender_address.0)),
+                data = %hex::encode(&transaction.data),
+                gas = %gas,
+                gas_price = %transaction.t_price,
+                send_eth = %transaction.t_value,
+                "Transaction [CREATE]"
+                );
                 self.contract_creation(
                     state,
                     &mut substate,
@@ -150,7 +150,7 @@ impl TransactionExecution for LEVIATHAN {
                     None,
                     true,
                     block_header,
-                    )
+                )
             }
 
             TxKind::Call(to_address) => {
@@ -158,14 +158,14 @@ impl TransactionExecution for LEVIATHAN {
                 substate.a_touch.push(to_address.clone());
                 //デバック出力
                 tracing::info!(
-                    sender_address =  format_args!("0x{}", hex::encode(sender_address.0)),
-                    to_address =  format_args!("0x{}", hex::encode(to_address.0)),
-                    data = %hex::encode(&transaction.data),
-                    gas = %gas,
-                    gas_price = %transaction.t_price,
-                    send_eth = %transaction.t_value,
-                    "Transaction [CALL]"
-                    );
+                sender_address =  format_args!("0x{}", hex::encode(sender_address.0)),
+                to_address =  format_args!("0x{}", hex::encode(to_address.0)),
+                data = %hex::encode(&transaction.data),
+                gas = %gas,
+                gas_price = %transaction.t_price,
+                send_eth = %transaction.t_value,
+                "Transaction [CALL]"
+                );
                 self.message_call(
                     state,
                     &mut substate,
@@ -181,7 +181,7 @@ impl TransactionExecution for LEVIATHAN {
                     0,
                     true,
                     block_header,
-                    )
+                )
             }
         };
 

--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -8,7 +8,7 @@ use crate::leviathan::world_state::{Account, MptAccount, WorldState};
 use crate::my_trait::leviathan_trait::{
     ContractCreation, MessageCall, State, TransactionChecks, TransactionExecution,
 };
-use alloy_primitives::{Address, U256, hex, keccak256};
+use alloy_primitives::{Address, U256, hex, keccak256, TxKind};
 use alloy_rlp::Encodable;
 use eth_trie::{EthTrie, Trie};
 use sha3::Digest;
@@ -73,7 +73,7 @@ impl TransactionExecution for LEVIATHAN {
         }
 
         let mut contract_gas = U256::ZERO;
-        if transaction.t_to.is_none() {
+        if let TxKind::Create = transaction.t_to {
             //コントラクト作成追加費
             if self.version >= VersionId::Homestead {
                 //Homestead以降
@@ -126,60 +126,63 @@ impl TransactionExecution for LEVIATHAN {
         gas = gas.saturating_sub(all_gas);
 
         //=======ステップ3===========
-        let result = if transaction.t_to.is_none() {
-            //デバック出力
-            tracing::info!(
-            sender_address =  format_args!("0x{}", hex::encode(sender_address.0)),
-            data = %hex::encode(&transaction.data),
-            gas = %gas,
-            gas_price = %transaction.t_price,
-            send_eth = %transaction.t_value,
-            "Transaction [CREATE]"
-            );
-            self.contract_creation(
-                state,
-                &mut substate,
-                sender_address.clone(),
-                sender_address.clone(),
-                gas,
-                transaction.t_price,
-                transaction.t_value,
-                transaction.data,
-                0,
-                None,
-                true,
-                block_header,
-            )
-        } else {
-            let to_address = transaction.t_to.unwrap();
-            //a_touchにトランザクションの基本要素（宛先）を追加
-            substate.a_touch.push(to_address.clone());
-            //デバック出力
-            tracing::info!(
-            sender_address =  format_args!("0x{}", hex::encode(sender_address.0)),
-            to_address =  format_args!("0x{}", hex::encode(to_address.0)),
-            data = %hex::encode(&transaction.data),
-            gas = %gas,
-            gas_price = %transaction.t_price,
-            send_eth = %transaction.t_value,
-            "Transaction [CALL]"
-            );
-            self.message_call(
-                state,
-                &mut substate,
-                sender_address.clone(),
-                sender_address.clone(),
-                to_address.clone(),
-                to_address.clone(),
-                gas,
-                transaction.t_price,
-                transaction.t_value,
-                transaction.t_value,
-                transaction.data,
-                0,
-                true,
-                block_header,
-            )
+        let result = match transaction.t_to {
+            TxKind::Create => {
+                //デバック出力
+                tracing::info!(
+                    sender_address =  format_args!("0x{}", hex::encode(sender_address.0)),
+                    data = %hex::encode(&transaction.data),
+                    gas = %gas,
+                    gas_price = %transaction.t_price,
+                    send_eth = %transaction.t_value,
+                    "Transaction [CREATE]"
+                    );
+                self.contract_creation(
+                    state,
+                    &mut substate,
+                    sender_address.clone(),
+                    sender_address.clone(),
+                    gas,
+                    transaction.t_price,
+                    transaction.t_value,
+                    transaction.data,
+                    0,
+                    None,
+                    true,
+                    block_header,
+                    )
+            }
+
+            TxKind::Call(to_address) => {
+                //a_touchにトランザクションの基本要素（宛先）を追加
+                substate.a_touch.push(to_address.clone());
+                //デバック出力
+                tracing::info!(
+                    sender_address =  format_args!("0x{}", hex::encode(sender_address.0)),
+                    to_address =  format_args!("0x{}", hex::encode(to_address.0)),
+                    data = %hex::encode(&transaction.data),
+                    gas = %gas,
+                    gas_price = %transaction.t_price,
+                    send_eth = %transaction.t_value,
+                    "Transaction [CALL]"
+                    );
+                self.message_call(
+                    state,
+                    &mut substate,
+                    sender_address.clone(),
+                    sender_address.clone(),
+                    to_address.clone(),
+                    to_address.clone(),
+                    gas,
+                    transaction.t_price,
+                    transaction.t_value,
+                    transaction.t_value,
+                    transaction.data,
+                    0,
+                    true,
+                    block_header,
+                    )
+            }
         };
 
         //払い戻しガス

--- a/src/leviathan/structs.rs
+++ b/src/leviathan/structs.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use alloy_primitives::{Address, U256, TxKind};
+use alloy_primitives::{Address, TxKind, U256};
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]

--- a/src/leviathan/structs.rs
+++ b/src/leviathan/structs.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use alloy_primitives::{Address, U256};
+use alloy_primitives::{Address, U256, TxKind};
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -25,7 +25,7 @@ pub struct Transaction {
     pub t_nonce: usize,
     pub t_gas_limit: U256,
     pub t_price: U256,
-    pub t_to: Option<Address>,
+    pub t_to: TxKind,
     pub t_value: U256,
     pub data: Vec<u8>,
     pub t_r: U256,

--- a/src/leviathan/transaction_check.rs
+++ b/src/leviathan/transaction_check.rs
@@ -4,7 +4,7 @@ use crate::leviathan::leviathan::LEVIATHAN;
 use crate::leviathan::structs::{BlockHeader, Transaction, VersionId};
 use crate::leviathan::world_state::WorldState;
 use crate::my_trait::leviathan_trait::{State, TransactionChecks};
-use alloy_primitives::{Address, U256, TxKind};
+use alloy_primitives::{Address, TxKind, U256};
 use alloy_rlp::{Encodable, Header};
 use bytes::BytesMut;
 use secp256k1::{

--- a/src/leviathan/transaction_check.rs
+++ b/src/leviathan/transaction_check.rs
@@ -4,7 +4,7 @@ use crate::leviathan::leviathan::LEVIATHAN;
 use crate::leviathan::structs::{BlockHeader, Transaction, VersionId};
 use crate::leviathan::world_state::WorldState;
 use crate::my_trait::leviathan_trait::{State, TransactionChecks};
-use alloy_primitives::{Address, U256};
+use alloy_primitives::{Address, U256, TxKind};
 use alloy_rlp::{Encodable, Header};
 use bytes::BytesMut;
 use secp256k1::{
@@ -29,8 +29,8 @@ impl TransactionChecks for LEVIATHAN {
         payload_length += transaction.t_gas_limit.length();
 
         let to_slice = match &transaction.t_to {
-            Some(address) => address.0.as_slice(),
-            None => &[], // 空のバイト列
+            TxKind::Call(address) => address.0.as_slice(),
+            TxKind::Create => &[], // 空のバイト列
         };
         payload_length += to_slice.length();
         payload_length += transaction.t_value.length();
@@ -112,7 +112,7 @@ impl TransactionChecks for LEVIATHAN {
         //Initコードが49152バイト以下
         if self.version >= VersionId::Shanghai {
             //Shanghai以降
-            if transaction.t_to.is_none() && transaction.data.len() > 49152 {
+            if transaction.t_to.is_create() && transaction.data.len() > 49152 {
                 return Err("Initコードが49152バイトを超えている");
             }
         }

--- a/src/solidity_utils.rs
+++ b/src/solidity_utils.rs
@@ -3,7 +3,7 @@ use crate::leviathan::structs::{BlockHeader, Log, Transaction, VersionId};
 use crate::leviathan::world_state::{Account, WorldState};
 use crate::my_trait::leviathan_trait::{State, TransactionExecution};
 
-use alloy_primitives::{Address, Bytes, U256, hex, keccak256, uint};
+use alloy_primitives::{Address, Bytes, U256, hex, keccak256, uint, TxKind};
 use alloy_rlp::{Encodable, Header};
 use bytes::BytesMut;
 use secp256k1::{Message, Secp256k1, SecretKey};
@@ -107,7 +107,7 @@ pub fn deploy_contract(
 
     let transaction = Transaction {
         data: init_code,
-        t_to: None,
+        t_to: TxKind::Create,
         t_gas_limit: gas_limit,
         t_price: gas_price,
         t_value: eth,
@@ -196,7 +196,7 @@ pub fn call_contract(
 
     let transaction = Transaction {
         data,
-        t_to: Some(contract_addr),
+        t_to: TxKind::Call(contract_addr),
         t_gas_limit: gas_limit,
         t_price: gas_price,
         t_value: eth,
@@ -258,7 +258,7 @@ pub fn deploy_contract_raw(
 
     let transaction = Transaction {
         data: init_code,
-        t_to: None,
+        t_to: TxKind::Create,
         t_gas_limit: gas_limit,
         t_price: gas_price,
         t_value: eth,

--- a/src/solidity_utils.rs
+++ b/src/solidity_utils.rs
@@ -3,7 +3,7 @@ use crate::leviathan::structs::{BlockHeader, Log, Transaction, VersionId};
 use crate::leviathan::world_state::{Account, WorldState};
 use crate::my_trait::leviathan_trait::{State, TransactionExecution};
 
-use alloy_primitives::{Address, Bytes, U256, hex, keccak256, uint, TxKind};
+use alloy_primitives::{Address, Bytes, TxKind, U256, hex, keccak256, uint};
 use alloy_rlp::{Encodable, Header};
 use bytes::BytesMut;
 use secp256k1::{Message, Secp256k1, SecretKey};

--- a/tests/state_runner.rs
+++ b/tests/state_runner.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::io::Write;
 
 // alloy_primitives の hex を使用して E0433 を解消
-use alloy_primitives::{Address, U256, hex, keccak256};
+use alloy_primitives::{Address, TxKind, U256, hex, keccak256};
 
 // 署名生成のためのクレート
 use alloy_rlp::{Encodable, Header};
@@ -93,7 +93,7 @@ fn sign_transaction(
     nonce: U256,
     gas_price: U256,
     gas_limit: U256,
-    to: Option<Address>,
+    to: TxKind,
     value: U256,
     data: &[u8],
     secret_key_hex: &str,
@@ -105,8 +105,8 @@ fn sign_transaction(
     payload_length += gas_limit.length();
 
     let to_slice = match &to {
-        Some(addr) => addr.0.as_slice(),
-        None => &[], // 空のバイト列
+        TxKind::Call(addr) => addr.0.as_slice(),
+        TxKind::Create => &[], // 空のバイト列
     };
     payload_length += to_slice.length();
     payload_length += value.length();
@@ -406,9 +406,9 @@ fn state_test() {
                                     let gas_limit = parse_u256(gas_limit_str);
                                     let value = parse_u256(value_str);
                                     let to_address = if test_data.transaction.to.is_empty() {
-                                        None
+                                        TxKind::Create
                                     } else {
-                                        Some(parse_address(&test_data.transaction.to))
+                                        TxKind::Call(parse_address(&test_data.transaction.to))
                                     };
                                     let nonce = parse_u256(&test_data.transaction.nonce);
                                     let gas_price = parse_u256(&test_data.transaction.gas_price);


### PR DESCRIPTION
## 概要（What）

Transaction構造体における宛先フィールド（t_to）の型を`Option<Address>`から`alloy_primitives::TxKind`へ変更しました。
また、この型変更に伴い、EVM実行ロジック本体およびテストランナーの適合修正を実施しました。

## 背景・課題（Why）
CometBFTから受信した生のバイト列（Raw Transaction）から、alloy_rlp を用いてTransaction構造体全体を自動デコードする機能の実装において、既存の型定義ではデコードエラーが発生していました。

Ethereumの仕様では、コントラクト作成時の宛先（to）は「空のバイト列（&[]）」として表現されます。従来は手動エンコードを用いていたため、None の場合に空配列を渡すことで問題なく動作していました。
しかし、alloy_rlp の自動マクロは Option 型を「リストからの要素省略」と解釈してしまうため、要素数を維持したまま空データを要求するEthereumの厳密なRLP仕様と衝突していました。

## 詳細な修正内容（How）
### 型の安全性とRLP互換性の向上
Transaction 構造体の t_to フィールドを TxKind に変更。
これにより、「特定のアドレス（Call）」または「空のバイト列（Create）」を型レベルで正確に表現できるようになり、Ethereum標準の自動エンコード/デコードに完全対応しました。

- 対象ファイル: Leviathan.rs, transaction_check.rs

### テストランナーの適合
t_to の型変更に伴い、StateTest等を実行するテストランナー側の受け渡しロジックを TxKind に対応するようにリファクタリングしました。

## テスト結果・影響範囲
- ステータス: 全テストパス（影響なし）
- テストランナー改修後もすべてのEVMテストスイートが正常に動作し、ロジック変更によるデグレや副作用が発生していないことを確認済みです。