### PR TITLE
feat: StateDBのRocksDB完全移行とOverlayキャッシュ・バイトコード永続化の実装

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2621,6 +2621,7 @@ dependencies = [
  "sha2",
  "sha3",
  "stacker",
+ "tempfile",
  "tendermint-abci",
  "tendermint-proto",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1734,6 +1734,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "flex-error"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c606d892c9de11507fa0dcffc116434f94e105d0bbdc4e405b61519464c49d7b"
+dependencies = [
+ "paste",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2545,6 +2554,8 @@ dependencies = [
  "sha2",
  "sha3",
  "stacker",
+ "tendermint-abci",
+ "tendermint-proto",
  "tracing",
  "tracing-subscriber 0.3.23",
 ]
@@ -3343,6 +3354,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "psm"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3441,7 +3475,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3886,7 +3920,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4163,6 +4197,16 @@ dependencies = [
  "js-sys",
  "serde",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -4459,6 +4503,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "subtle-encoding"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcb1ed7b8330c5eed5441052651dd7a12c75e2ed88f2ec024ae1fa3a5e59945"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4546,6 +4599,34 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tendermint-abci"
+version = "0.40.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87265abf4063fc70605f33fd0117c0bea375d2b05a269aaf317e3ba9e6b5e6b5"
+dependencies = [
+ "bytes",
+ "flex-error",
+ "prost",
+ "tendermint-proto",
+ "tracing",
+]
+
+[[package]]
+name = "tendermint-proto"
+version = "0.40.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c40e13d39ca19082d8a7ed22de7595979350319833698f8b1080f29620a094"
+dependencies = [
+ "bytes",
+ "flex-error",
+ "prost",
+ "serde",
+ "serde_bytes",
+ "subtle-encoding",
+ "time",
 ]
 
 [[package]]
@@ -5835,7 +5916,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -662,6 +662,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,13 +835,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -872,6 +911,17 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -1962,6 +2012,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "globset"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2453,6 +2509,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2547,6 +2613,7 @@ dependencies = [
  "num-bigint",
  "rand 0.8.5",
  "ripemd",
+ "rocksdb",
  "rsa",
  "secp256k1",
  "serde",
@@ -2576,6 +2643,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2591,6 +2668,32 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.4",
+]
+
+[[package]]
+name = "librocksdb-sys"
+version = "0.17.3+10.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
+dependencies = [
+ "bindgen",
+ "bzip2-sys",
+ "cc",
+ "libc",
+ "libz-sys",
+ "lz4-sys",
+ "zstd-sys",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2664,6 +2767,16 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "lz4_flex"
@@ -2746,6 +2859,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2788,6 +2907,16 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -3818,6 +3947,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rocksdb"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddb7af00d2b17dbd07d82c0063e25411959748ff03e8d4f96134c2ff41fce34f"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
 ]
 
 [[package]]
@@ -6384,3 +6523,13 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,4 @@ ark-circom = { version = "0.5.0-alpha" }
 tendermint-abci = "0.40.4"
 tendermint-proto = "0.40.4"
 rocksdb = "0.24.0"
+tempfile = "3.27.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,5 @@ ark-serialize = "0.5.0"
 light-poseidon = "0.4.0"
 # Cargo.toml に追記
 ark-circom = { version = "0.5.0-alpha" }
+tendermint-abci = "0.40.4"
+tendermint-proto = "0.40.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,4 @@ light-poseidon = "0.4.0"
 ark-circom = { version = "0.5.0-alpha" }
 tendermint-abci = "0.40.4"
 tendermint-proto = "0.40.4"
+rocksdb = "0.24.0"

--- a/gas_analy/rsa_benchmarks.csv
+++ b/gas_analy/rsa_benchmarks.csv
@@ -10,3 +10,4 @@ PayloadLen:547,Status:Success,Time_us:154
 PayloadLen:547,Status:Success,Time_us:170
 PayloadLen:547,Status:Success,Time_us:171
 PayloadLen:547,Status:Success,Time_us:3368
+PayloadLen:547,Status:Success,Time_us:193

--- a/src/bin/abci_node.rs
+++ b/src/bin/abci_node.rs
@@ -4,11 +4,32 @@ use tendermint_proto::abci::{
     ResponseCommit, ResponseFinalizeBlock, ResponseInfo,
 };
 use tracing::{info, Level};
+use std::sync::Arc;
+use std::sync::Mutex;
 
-#[derive(Default, Clone)]
-struct LeviathanMockApp;
+//自作構造体
+use leviathan_v2::leviathan::leviathan::LEVIATHAN;
+use leviathan_v2::leviathan::structs::VersionId;
+use leviathan_v2::leviathan::world_state::{Account, WorldState};
 
-impl Application for LeviathanMockApp {
+
+#[derive(Clone)]
+struct LeviathanApp {
+    state: Arc<Mutex<WorldState>>,
+    leviathan: Arc<Mutex<LEVIATHAN>>,
+}
+
+impl LeviathanApp {
+    pub fn new(version: VersionId) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(WorldState::new())),
+            leviathan: Arc::new(Mutex::new(LEVIATHAN::new(version))),
+        }
+    }
+}
+
+
+impl Application for LeviathanApp {
     /// 1. Info: CometBFT起動時に呼ばれる状態同期
     fn info(&self, _req: RequestInfo) -> ResponseInfo {
         info!("[INFO] CometBFTからInfoリクエストを受信しました");
@@ -67,7 +88,7 @@ fn main() {
     tracing_subscriber::fmt().with_max_level(Level::INFO).init();
     info!("Leviathan ABCI Mock Serverを起動中...");
 
-    let app = LeviathanMockApp::default();
+    let app = LeviathanApp::new(VersionId::Constantinople);
     
     let server = ServerBuilder::default()
         .bind("127.0.0.1:26658", app)

--- a/src/bin/abci_node.rs
+++ b/src/bin/abci_node.rs
@@ -1,0 +1,78 @@
+use tendermint_abci::{Application, ServerBuilder};
+use tendermint_proto::abci::{
+    ExecTxResult, RequestCheckTx, RequestFinalizeBlock, RequestInfo, ResponseCheckTx,
+    ResponseCommit, ResponseFinalizeBlock, ResponseInfo,
+};
+use tracing::{info, Level};
+
+#[derive(Default, Clone)]
+struct LeviathanMockApp;
+
+impl Application for LeviathanMockApp {
+    /// 1. Info: CometBFT起動時に呼ばれる状態同期
+    fn info(&self, _req: RequestInfo) -> ResponseInfo {
+        info!("[INFO] CometBFTからInfoリクエストを受信しました");
+        ResponseInfo {
+            data: "leviathan-mock".to_string(),
+            version: "0.1.0".to_string(),
+            app_version: 1,
+            last_block_height: 0,
+            last_block_app_hash: vec![].into(),
+        }
+    }
+
+    /// 2. CheckTx: メモリープール投入前の単体検証
+    fn check_tx(&self, req: RequestCheckTx) -> ResponseCheckTx {
+        info!("[CHECK_TX] トランザクションを受信: {} bytes", req.tx.len());
+        ResponseCheckTx {
+            code: 0, // 0 = OK (受け入れ)
+            ..Default::default()
+        }
+    }
+
+    /// 3. FinalizeBlock: ブロックの実行とStateRootの計算 (旧 DeliverTx + Begin/EndBlock)
+    fn finalize_block(&self, req: RequestFinalizeBlock) -> ResponseFinalizeBlock {
+        info!("[FINALIZE_BLOCK] ブロック生成開始: {} 個のTXが含まれています", req.txs.len());
+        
+        // ブロック内の各トランザクションに対する実行結果（すべて成功として返す）
+        let tx_results = req.txs.iter().map(|tx| {
+            info!("   - TX実行: {} bytes", tx.len());
+            ExecTxResult {
+                code: 0, // 0 = 実行成功
+                ..Default::default()
+            }
+        }).collect();
+
+        // 実行完了後のStateRoot（AppHash）は、このメソッドで返す仕様に変更されました
+        let dummy_app_hash = vec![0u8; 32];
+
+        ResponseFinalizeBlock {
+            tx_results,
+            app_hash: dummy_app_hash.into(),
+            ..Default::default()
+        }
+    }
+
+    /// 4. Commit: 状態の永続化シグナル
+    fn commit(&self) -> ResponseCommit {
+        info!("[COMMIT] ブロックのステートを確定しました");
+        ResponseCommit {
+            retain_height: 0,
+        }
+    }
+}
+
+fn main() {
+    // ログの初期化
+    tracing_subscriber::fmt().with_max_level(Level::INFO).init();
+    info!("Leviathan ABCI Mock Serverを起動中...");
+
+    let app = LeviathanMockApp::default();
+    
+    let server = ServerBuilder::default()
+        .bind("127.0.0.1:26658", app)
+        .expect("サーバーのバインドに失敗しました");
+
+    info!("ポート 26658 でCometBFTからの接続を待機しています...");
+    server.listen().expect("サーバーの実行に失敗しました");
+}

--- a/src/bin/abci_node/main.rs
+++ b/src/bin/abci_node/main.rs
@@ -1,5 +1,6 @@
 mod tx_check;
 
+use alloy_rlp::{Decodable, RlpDecodable, RlpEncodable};
 use std::sync::Arc;
 use std::sync::Mutex;
 use tendermint_abci::{Application, ServerBuilder};
@@ -11,7 +12,7 @@ use tracing::{Level, info};
 
 //自作構造体
 use leviathan_v2::leviathan::leviathan::LEVIATHAN;
-use leviathan_v2::leviathan::structs::VersionId;
+use leviathan_v2::leviathan::structs::{Transaction, VersionId};
 use leviathan_v2::leviathan::world_state::{Account, WorldState};
 use tx_check::Tx_Checker;
 
@@ -48,9 +49,42 @@ impl Application for LeviathanApp {
     /// 2. CheckTx: メモリープール投入前の単体検証
     fn check_tx(&self, req: RequestCheckTx) -> ResponseCheckTx {
         info!("[CHECK_TX] トランザクションを受信: {} bytes", req.tx.len());
-        ResponseCheckTx {
-            code: 0, // 0 = OK (受け入れ)
-            ..Default::default()
+
+        let mut raw_tx_slice = req.tx.as_ref();
+
+        match Transaction::decode(&mut raw_tx_slice) {
+            Ok(transaction) => {
+                tracing::info!(
+                    "[CHECK_TX] デコード成功: Nonce={}, GasLimit={}",
+                    transaction.t_nonce,
+                    transaction.t_gas_limit
+                );
+
+                let is_valid = self.validate_transaction(&transaction);
+                if !is_valid {
+                    return ResponseCheckTx {
+                        code: 1, // 不正なトランザクションは弾く
+                        log: "Validation Failed".to_string(),
+                        ..Default::default()
+                    };
+                }
+
+                ResponseCheckTx {
+                    code: 0,
+                    ..Default::default()
+                }
+            }
+            Err(err) => {
+                // デコード失敗（スパムやEthereum互換ではないフォーマット）
+                tracing::warn!("[CHECK_TX] RLPデコード失敗: {:?}", err);
+
+                // codeを非ゼロ（例: 1）にしてCometBFTに弾かせる
+                ResponseCheckTx {
+                    code: 1,
+                    log: format!("RLP Decode Error: {}", err),
+                    ..Default::default()
+                }
+            }
         }
     }
 

--- a/src/bin/abci_node/main.rs
+++ b/src/bin/abci_node/main.rs
@@ -24,9 +24,9 @@ struct LeviathanApp {
 }
 
 impl LeviathanApp {
-    pub fn new(version: VersionId) -> Self {
+    pub fn new(version: VersionId, db_path: &str) -> Self {
         Self {
-            state: Arc::new(Mutex::new(WorldState::new())),
+            state: Arc::new(Mutex::new(WorldState::new(db_path))),
             leviathan: Arc::new(Mutex::new(LEVIATHAN::new(version))),
             version,
         }
@@ -130,7 +130,10 @@ fn main() {
     tracing_subscriber::fmt().with_max_level(Level::INFO).init();
     info!("Leviathan ABCI Mock Serverを起動中...");
 
-    let app = LeviathanApp::new(VersionId::Constantinople);
+    let db_path = "data/leviathan_db";
+    std::fs::create_dir_all(db_path).expect("DBディレクトリの作成に失敗しました");
+
+    let app = LeviathanApp::new(VersionId::Constantinople, db_path);
 
     let server = ServerBuilder::default()
         .bind("127.0.0.1:26658", app)

--- a/src/bin/abci_node/main.rs
+++ b/src/bin/abci_node/main.rs
@@ -1,3 +1,5 @@
+mod tx_check;
+
 use tendermint_abci::{Application, ServerBuilder};
 use tendermint_proto::abci::{
     ExecTxResult, RequestCheckTx, RequestFinalizeBlock, RequestInfo, ResponseCheckTx,
@@ -11,12 +13,14 @@ use std::sync::Mutex;
 use leviathan_v2::leviathan::leviathan::LEVIATHAN;
 use leviathan_v2::leviathan::structs::VersionId;
 use leviathan_v2::leviathan::world_state::{Account, WorldState};
+use tx_check::Tx_Checker;
 
 
 #[derive(Clone)]
 struct LeviathanApp {
     state: Arc<Mutex<WorldState>>,
     leviathan: Arc<Mutex<LEVIATHAN>>,
+    version: VersionId,
 }
 
 impl LeviathanApp {
@@ -24,6 +28,7 @@ impl LeviathanApp {
         Self {
             state: Arc::new(Mutex::new(WorldState::new())),
             leviathan: Arc::new(Mutex::new(LEVIATHAN::new(version))),
+            version,
         }
     }
 }

--- a/src/bin/abci_node/main.rs
+++ b/src/bin/abci_node/main.rs
@@ -1,20 +1,19 @@
 mod tx_check;
 
+use std::sync::Arc;
+use std::sync::Mutex;
 use tendermint_abci::{Application, ServerBuilder};
 use tendermint_proto::abci::{
     ExecTxResult, RequestCheckTx, RequestFinalizeBlock, RequestInfo, ResponseCheckTx,
     ResponseCommit, ResponseFinalizeBlock, ResponseInfo,
 };
-use tracing::{info, Level};
-use std::sync::Arc;
-use std::sync::Mutex;
+use tracing::{Level, info};
 
 //自作構造体
 use leviathan_v2::leviathan::leviathan::LEVIATHAN;
 use leviathan_v2::leviathan::structs::VersionId;
 use leviathan_v2::leviathan::world_state::{Account, WorldState};
 use tx_check::Tx_Checker;
-
 
 #[derive(Clone)]
 struct LeviathanApp {
@@ -32,7 +31,6 @@ impl LeviathanApp {
         }
     }
 }
-
 
 impl Application for LeviathanApp {
     /// 1. Info: CometBFT起動時に呼ばれる状態同期
@@ -58,16 +56,23 @@ impl Application for LeviathanApp {
 
     /// 3. FinalizeBlock: ブロックの実行とStateRootの計算 (旧 DeliverTx + Begin/EndBlock)
     fn finalize_block(&self, req: RequestFinalizeBlock) -> ResponseFinalizeBlock {
-        info!("[FINALIZE_BLOCK] ブロック生成開始: {} 個のTXが含まれています", req.txs.len());
-        
+        info!(
+            "[FINALIZE_BLOCK] ブロック生成開始: {} 個のTXが含まれています",
+            req.txs.len()
+        );
+
         // ブロック内の各トランザクションに対する実行結果（すべて成功として返す）
-        let tx_results = req.txs.iter().map(|tx| {
-            info!("   - TX実行: {} bytes", tx.len());
-            ExecTxResult {
-                code: 0, // 0 = 実行成功
-                ..Default::default()
-            }
-        }).collect();
+        let tx_results = req
+            .txs
+            .iter()
+            .map(|tx| {
+                info!("   - TX実行: {} bytes", tx.len());
+                ExecTxResult {
+                    code: 0, // 0 = 実行成功
+                    ..Default::default()
+                }
+            })
+            .collect();
 
         // 実行完了後のStateRoot（AppHash）は、このメソッドで返す仕様に変更されました
         let dummy_app_hash = vec![0u8; 32];
@@ -82,9 +87,7 @@ impl Application for LeviathanApp {
     /// 4. Commit: 状態の永続化シグナル
     fn commit(&self) -> ResponseCommit {
         info!("[COMMIT] ブロックのステートを確定しました");
-        ResponseCommit {
-            retain_height: 0,
-        }
+        ResponseCommit { retain_height: 0 }
     }
 }
 
@@ -94,7 +97,7 @@ fn main() {
     info!("Leviathan ABCI Mock Serverを起動中...");
 
     let app = LeviathanApp::new(VersionId::Constantinople);
-    
+
     let server = ServerBuilder::default()
         .bind("127.0.0.1:26658", app)
         .expect("サーバーのバインドに失敗しました");

--- a/src/bin/abci_node/tx_check.rs
+++ b/src/bin/abci_node/tx_check.rs
@@ -1,11 +1,11 @@
 use crate::LeviathanApp;
+use alloy_primitives::{Address, TxKind, U256};
+use alloy_rlp::{Encodable, Header};
+use bytes::BytesMut;
 use leviathan_v2::leviathan::leviathan::LEVIATHAN;
 use leviathan_v2::leviathan::structs::{Transaction, VersionId};
 use leviathan_v2::leviathan::world_state::WorldState;
 use leviathan_v2::my_trait::leviathan_trait::{State, TransactionChecks};
-use alloy_primitives::{Address, U256};
-use alloy_rlp::{Encodable, Header};
-use bytes::BytesMut;
 use secp256k1::{
     Message, Secp256k1,
     ecdsa::{RecoverableSignature, RecoveryId},
@@ -17,10 +17,7 @@ pub trait Tx_Checker {
 }
 
 impl Tx_Checker for LeviathanApp {
-    fn validate_transaction(
-        &mut self,
-        transaction: &Transaction,
-        ) -> bool {
+    fn validate_transaction(&mut self, transaction: &Transaction) -> bool {
         //=======ステップ1===========
         //【初期ガスの計算】
         let base_gas = U256::from(21000); //基本料金
@@ -50,7 +47,7 @@ impl Tx_Checker for LeviathanApp {
         }
 
         let mut contract_gas = U256::ZERO;
-        if transaction.t_to.is_none() {
+        if transaction.t_to.is_create() {
             //コントラクト作成追加費
             if self.version >= VersionId::Homestead {
                 //Homestead以降
@@ -78,8 +75,8 @@ impl Tx_Checker for LeviathanApp {
         payload_length += transaction.t_gas_limit.length();
 
         let to_slice = match &transaction.t_to {
-            Some(address) => address.0.as_slice(),
-            None => &[], // 空のバイト列
+            TxKind::Call(address) => address.0.as_slice(),
+            TxKind::Create => &[], // 空のバイト列
         };
         payload_length += to_slice.length();
         payload_length += transaction.t_value.length();
@@ -176,7 +173,7 @@ impl Tx_Checker for LeviathanApp {
         //Initコードが49152バイト以下
         if self.version >= VersionId::Shanghai {
             //Shanghai以降
-            if transaction.t_to.is_none() && transaction.data.len() > 49152 {
+            if transaction.t_to.is_create() && transaction.data.len() > 49152 {
                 tracing::warn!("Initコードが49152バイトを超えている");
                 return false;
             }

--- a/src/bin/abci_node/tx_check.rs
+++ b/src/bin/abci_node/tx_check.rs
@@ -13,11 +13,11 @@ use secp256k1::{
 use sha3::{Digest, Keccak256};
 
 pub trait Tx_Checker {
-    fn validate_transaction(&mut self, transaction: &Transaction) -> bool;
+    fn validate_transaction(&self, transaction: &Transaction) -> bool;
 }
 
 impl Tx_Checker for LeviathanApp {
-    fn validate_transaction(&mut self, transaction: &Transaction) -> bool {
+    fn validate_transaction(&self, transaction: &Transaction) -> bool {
         //=======ステップ1===========
         //【初期ガスの計算】
         let base_gas = U256::from(21000); //基本料金

--- a/src/bin/abci_node/tx_check.rs
+++ b/src/bin/abci_node/tx_check.rs
@@ -1,0 +1,187 @@
+use crate::LeviathanApp;
+use leviathan_v2::leviathan::leviathan::LEVIATHAN;
+use leviathan_v2::leviathan::structs::{Transaction, VersionId};
+use leviathan_v2::leviathan::world_state::WorldState;
+use leviathan_v2::my_trait::leviathan_trait::{State, TransactionChecks};
+use alloy_primitives::{Address, U256};
+use alloy_rlp::{Encodable, Header};
+use bytes::BytesMut;
+use secp256k1::{
+    Message, Secp256k1,
+    ecdsa::{RecoverableSignature, RecoveryId},
+};
+use sha3::{Digest, Keccak256};
+
+pub trait Tx_Checker {
+    fn validate_transaction(&mut self, transaction: &Transaction) -> bool;
+}
+
+impl Tx_Checker for LeviathanApp {
+    fn validate_transaction(
+        &mut self,
+        transaction: &Transaction,
+        ) -> bool {
+        //=======ステップ1===========
+        //【初期ガスの計算】
+        let base_gas = U256::from(21000); //基本料金
+        let mut data_gas = U256::ZERO;
+        let mut index = 0;
+
+        //データに関するガス
+        if self.version < VersionId::Istanbul {
+            //Istanbul以前
+            while index < transaction.data.len() {
+                if transaction.data[index] == 0 {
+                    data_gas = data_gas.saturating_add(U256::from(4));
+                } else {
+                    data_gas = data_gas.saturating_add(U256::from(68));
+                }
+                index += 1;
+            }
+        } else {
+            while index < transaction.data.len() {
+                if transaction.data[index] == 0 {
+                    data_gas = data_gas.saturating_add(U256::from(4));
+                } else {
+                    data_gas = data_gas.saturating_add(U256::from(16));
+                }
+                index += 1;
+            }
+        }
+
+        let mut contract_gas = U256::ZERO;
+        if transaction.t_to.is_none() {
+            //コントラクト作成追加費
+            if self.version >= VersionId::Homestead {
+                //Homestead以降
+                contract_gas = contract_gas.saturating_add(U256::from(32000));
+
+                if self.version >= VersionId::Shanghai {
+                    //Shanghai以降
+                    //Initcodeのサイズに対する従量課金
+                    let words = U256::from(transaction.data.len()).saturating_add(U256::from(31))
+                        / U256::from(32);
+                    let word_gas = words.saturating_mul(U256::from(2));
+                    contract_gas = contract_gas.saturating_add(word_gas);
+                }
+            }
+        }
+        let all_gas = base_gas + data_gas + contract_gas;
+        //【事前支払いコスト】
+        let max_cost =
+            transaction.t_gas_limit.saturating_mul(transaction.t_price) + transaction.t_value;
+
+        // 1. 各要素のRLPペイロード長を事前計算する (alloy-rlpの特徴)
+        let mut payload_length = 0;
+        payload_length += transaction.t_nonce.length();
+        payload_length += transaction.t_price.length();
+        payload_length += transaction.t_gas_limit.length();
+
+        let to_slice = match &transaction.t_to {
+            Some(address) => address.0.as_slice(),
+            None => &[], // 空のバイト列
+        };
+        payload_length += to_slice.length();
+        payload_length += transaction.t_value.length();
+        payload_length += transaction.data.as_slice().length();
+
+        // 2. バッファを確保し、リストのヘッダーを書き込む
+        let mut out = BytesMut::with_capacity(payload_length + 10); // ヘッダー分少し余分に確保
+        Header {
+            list: true,
+            payload_length,
+        }
+        .encode(&mut out);
+
+        // 3. 要素を順次書き込む (U256のゼロ省略などはalloy-rlpが自動処理します)
+        transaction.t_nonce.encode(&mut out);
+        transaction.t_price.encode(&mut out);
+        transaction.t_gas_limit.encode(&mut out);
+        to_slice.encode(&mut out);
+        transaction.t_value.encode(&mut out);
+        transaction.data.as_slice().encode(&mut out);
+        let rlp_encoded = out.freeze();
+        //4. Keccak256でハッシュ化して32バイトのh(T)を得る
+        let mut hasher = Keccak256::new();
+        hasher.update(&rlp_encoded);
+        let tx_hash_bytes: [u8; 32] = hasher.finalize().into();
+        // --- 公開鍵のリカバリ部分 ---
+        let message = Message::from_digest(tx_hash_bytes);
+        let Ok(t_w_u64) = u64::try_from(transaction.t_w) else {
+            tracing::warn!("t_w is too large for u64");
+            return false;
+        };
+
+        let v_val = (t_w_u64 - 27) as u8;
+        // 【解決策5】 `from_i32` の代わりに `TryFrom::try_from` を使う
+        let Ok(recovery_id) = RecoveryId::try_from(v_val as i32) else {
+            tracing::warn!("Invalid v");
+            return false;
+        };
+        // 【解決策6】 `to_big_endian` の代わりに `to_be_bytes::<32>()` を使う
+        let mut sig_bytes = [0u8; 64];
+        sig_bytes[0..32].copy_from_slice(&transaction.t_r.to_be_bytes::<32>());
+        sig_bytes[32..64].copy_from_slice(&transaction.t_s.to_be_bytes::<32>());
+        let Ok(signature) = RecoverableSignature::from_compact(&sig_bytes, recovery_id) else {
+            tracing::warn!("Invalid signature");
+            return false;
+        };
+        let secp = Secp256k1::verification_only();
+        // 【解決策7】 最新版では `&message` ではなく `message` (値渡し) にする
+        let Ok(public_key) = secp.recover_ecdsa(message, &signature) else {
+            tracing::warn!("Failed to recover public key");
+            return false;
+        };
+        // あとは前回のコードと同じようにアドレスを抽出！
+        let uncompressed_pubkey = public_key.serialize_uncompressed();
+        let pubkey_hash = Keccak256::digest(&uncompressed_pubkey[1..65]);
+        let mut sender_address = [0u8; 20];
+        sender_address.copy_from_slice(&pubkey_hash[12..32]);
+        let sender_address = Address::new(sender_address);
+
+        //self.stateをロックして，中身のstateを取り出す
+        let mut state = self.state.lock().unwrap();
+
+        //Nonceの整合性
+        let Some(sender_nonce) = state.get_nonce(&sender_address) else {
+            tracing::warn!("送信者のアカウントが見つからない");
+            return false;
+        };
+        if sender_nonce as usize != transaction.t_nonce {
+            tracing::warn!("nonceが不一致");
+            return false;
+        }
+
+        //Codeの不在
+        let sender_code = state.get_code(&sender_address).unwrap();
+        if !sender_code.is_empty() {
+            tracing::warn!("送信者のアカウントにコントラクトコードがデプロイされている");
+            return false;
+        }
+
+        //ガスリミットの妥当性
+        let gas_limit = transaction.t_gas_limit;
+        if gas_limit < all_gas {
+            tracing::warn!("初期ガスが指定されたガスリミットを超えている");
+            return false;
+        }
+
+        //残高の妥当性
+        let sender_balance = state.get_balance(&sender_address).unwrap();
+        if sender_balance < max_cost {
+            tracing::warn!("送信者の残高が事前支払いコストを満たしていない");
+            return false;
+        }
+
+        //Initコードが49152バイト以下
+        if self.version >= VersionId::Shanghai {
+            //Shanghai以降
+            if transaction.t_to.is_none() && transaction.data.len() > 49152 {
+                tracing::warn!("Initコードが49152バイトを超えている");
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/leviathan/db.rs
+++ b/src/leviathan/db.rs
@@ -1,74 +1,87 @@
 use eth_trie::DB as EthTrieDB;
 use rocksdb::{DB as RocksDB, Error as RocksError, Options, WriteBatch};
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex}; 
 
-// カラムファミリ名の定義
 pub const CF_MPT: &str = "mpt_data";
 pub const CF_CODE: &str = "code_data";
 
+struct RocksDBInner {
+    batch: WriteBatch,
+    // 🌟 テスト環境では、この overlay が実質的なメインDBとして機能する
+    overlay: HashMap<Vec<u8>, Vec<u8>>,
+}
+
 pub struct RocksDBWrapper {
     db: Arc<RocksDB>,
-    // WriteBatch は Sync ではないため、Mutex を使ってスレッドセーフにします
-    batch: Mutex<WriteBatch>,
+    inner: Mutex<RocksDBInner>,
 }
 
 impl RocksDBWrapper {
-    /// RocksDBインスタンスを初期化し、ラッパーを生成します
     pub fn new(path: &str) -> Self {
         let mut opts = Options::default();
         opts.create_if_missing(true);
         opts.create_missing_column_families(true);
 
-        // 使用するカラムファミリを宣言
         let cfs = vec![CF_MPT, CF_CODE];
-        
-        // カラムファミリを有効にしてデータベースを開く
         let db = RocksDB::open_cf(&opts, path, cfs).expect("RocksDBのオープンに失敗しました");
         
         Self { 
             db: Arc::new(db),
-            batch: Mutex::new(WriteBatch::default()), // Mutex::new になっています
+            inner: Mutex::new(RocksDBInner {
+                batch: WriteBatch::default(),
+                overlay: HashMap::new(),
+            }),
         }
     }
 }
 
-// eth_trie::DB トレイトの実装
 impl EthTrieDB for RocksDBWrapper {
-    // 関連型 Error として、RocksDB のエラー型をそのまま使用する
     type Error = RocksError;
 
     fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
+        let inner = self.inner.lock().unwrap();
+        
+        // 🌟 常に Overlay キャッシュを最優先で確認！
+        // これにより、さっき insert したばかりのノードを確実に見つける
+        if let Some(value) = inner.overlay.get(key) {
+            return Ok(Some(value.clone()));
+        }
+        
+        // Overlay になければ、SSD(RocksDB本体)を探す
         let cf = self.db.cf_handle(CF_MPT).unwrap();
-        // RocksDBのget_cfは Result<Option<Vec<u8>>, rocksdb::Error> を返すのでそのまま返却
         self.db.get_cf(&cf, key)
     }
 
     fn insert(&self, key: &[u8], value: Vec<u8>) -> Result<(), Self::Error> {
-        // Mutex のロックを取得
-        let mut batch = self.batch.lock().unwrap();
+        let mut inner = self.inner.lock().unwrap();
         let cf = self.db.cf_handle(CF_MPT).unwrap();
         
-        batch.put_cf(&cf, key, value);
+        // バッチ(SSD書き込み予約)と Overlay(即時読み取り用) の両方に保存
+        inner.batch.put_cf(&cf, key, &value);
+        inner.overlay.insert(key.to_vec(), value);
         Ok(())
     }
 
     fn remove(&self, key: &[u8]) -> Result<(), Self::Error> {
-        // Mutex のロックを取得
-        let mut batch = self.batch.lock().unwrap();
+        let mut inner = self.inner.lock().unwrap();
         let cf = self.db.cf_handle(CF_MPT).unwrap();
         
-        batch.delete_cf(&cf, key);
+        inner.batch.delete_cf(&cf, key);
+        inner.overlay.remove(key);
         Ok(())
     }
 
     fn flush(&self) -> Result<(), Self::Error> {
-        // Mutex のロックを取得
-        let mut batch = self.batch.lock().unwrap();
+        let mut inner = self.inner.lock().unwrap();
+        let current_batch = std::mem::replace(&mut inner.batch, WriteBatch::default());
+        let result = self.db.write(current_batch);
         
-        // 現在のバッチを取り出し、空のバッチと入れ替える
-        let current_batch = std::mem::replace(&mut *batch, WriteBatch::default());
+        // 🌟 SSD書き込み成功時に Overlay をクリアする
+        if result.is_ok() {
+            inner.overlay.clear();
+        }
         
-        // アトミックにSSDへ書き込み、Result をそのまま返す
-        self.db.write(current_batch)
+        result
     }
 }

--- a/src/leviathan/db.rs
+++ b/src/leviathan/db.rs
@@ -1,7 +1,7 @@
 use eth_trie::DB as EthTrieDB;
 use rocksdb::{DB as RocksDB, Error as RocksError, Options, WriteBatch};
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex}; 
+use std::sync::{Arc, Mutex};
 
 pub const CF_MPT: &str = "mpt_data";
 pub const CF_CODE: &str = "code_data";
@@ -25,8 +25,8 @@ impl RocksDBWrapper {
 
         let cfs = vec![CF_MPT, CF_CODE];
         let db = RocksDB::open_cf(&opts, path, cfs).expect("RocksDBのオープンに失敗しました");
-        
-        Self { 
+
+        Self {
             db: Arc::new(db),
             inner: Mutex::new(RocksDBInner {
                 batch: WriteBatch::default(),
@@ -41,13 +41,13 @@ impl EthTrieDB for RocksDBWrapper {
 
     fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
         let inner = self.inner.lock().unwrap();
-        
+
         // 🌟 常に Overlay キャッシュを最優先で確認！
         // これにより、さっき insert したばかりのノードを確実に見つける
         if let Some(value) = inner.overlay.get(key) {
             return Ok(Some(value.clone()));
         }
-        
+
         // Overlay になければ、SSD(RocksDB本体)を探す
         let cf = self.db.cf_handle(CF_MPT).unwrap();
         self.db.get_cf(&cf, key)
@@ -56,7 +56,7 @@ impl EthTrieDB for RocksDBWrapper {
     fn insert(&self, key: &[u8], value: Vec<u8>) -> Result<(), Self::Error> {
         let mut inner = self.inner.lock().unwrap();
         let cf = self.db.cf_handle(CF_MPT).unwrap();
-        
+
         // バッチ(SSD書き込み予約)と Overlay(即時読み取り用) の両方に保存
         inner.batch.put_cf(&cf, key, &value);
         inner.overlay.insert(key.to_vec(), value);
@@ -66,7 +66,7 @@ impl EthTrieDB for RocksDBWrapper {
     fn remove(&self, key: &[u8]) -> Result<(), Self::Error> {
         let mut inner = self.inner.lock().unwrap();
         let cf = self.db.cf_handle(CF_MPT).unwrap();
-        
+
         inner.batch.delete_cf(&cf, key);
         inner.overlay.remove(key);
         Ok(())
@@ -76,12 +76,12 @@ impl EthTrieDB for RocksDBWrapper {
         let mut inner = self.inner.lock().unwrap();
         let current_batch = std::mem::replace(&mut inner.batch, WriteBatch::default());
         let result = self.db.write(current_batch);
-        
+
         // 🌟 SSD書き込み成功時に Overlay をクリアする
         if result.is_ok() {
             inner.overlay.clear();
         }
-        
+
         result
     }
 }

--- a/src/leviathan/db.rs
+++ b/src/leviathan/db.rs
@@ -1,15 +1,15 @@
-use eth_trie::{DB as EthTrieDB, DBError};
-use rocksdb::{DB as RocksDB, Options, WriteBatch};
-use std::sync::{Arc, RwLock};
+use eth_trie::DB as EthTrieDB;
+use rocksdb::{DB as RocksDB, Error as RocksError, Options, WriteBatch};
+use std::sync::{Arc, Mutex}; 
 
 // カラムファミリ名の定義
 pub const CF_MPT: &str = "mpt_data";
-pub const CF_CODE: &str = "code_data"; // 将来のコード永続化用に予約
+pub const CF_CODE: &str = "code_data";
 
 pub struct RocksDBWrapper {
     db: Arc<RocksDB>,
-    // 内部可変性(Interior Mutability)を持たせ、&selfのままバッチを更新できるようにする
-    batch: RwLock<WriteBatch>,
+    // WriteBatch は Sync ではないため、Mutex を使ってスレッドセーフにします
+    batch: Mutex<WriteBatch>,
 }
 
 impl RocksDBWrapper {
@@ -27,45 +27,48 @@ impl RocksDBWrapper {
         
         Self { 
             db: Arc::new(db),
-            batch: RwLock::new(WriteBatch::default()),
+            batch: Mutex::new(WriteBatch::default()), // Mutex::new になっています
         }
     }
 }
 
 // eth_trie::DB トレイトの実装
 impl EthTrieDB for RocksDBWrapper {
-    // MPTからノードを読み込む（SSDから直接読み込み）
-    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, DBError> {
+    // 関連型 Error として、RocksDB のエラー型をそのまま使用する
+    type Error = RocksError;
+
+    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
         let cf = self.db.cf_handle(CF_MPT).unwrap();
-        self.db.get_cf(&cf, key).map_err(|e| DBError::Custom(e.to_string()))
+        // RocksDBのget_cfは Result<Option<Vec<u8>>, rocksdb::Error> を返すのでそのまま返却
+        self.db.get_cf(&cf, key)
     }
 
-    // MPTに新しいノードを挿入する（メモリ上のWriteBatchに積むだけでSSDには書かない）
-    fn insert(&self, key: &[u8], value: Vec<u8>) -> Result<(), DBError> {
-        let mut batch = self.batch.write().unwrap();
+    fn insert(&self, key: &[u8], value: Vec<u8>) -> Result<(), Self::Error> {
+        // Mutex のロックを取得
+        let mut batch = self.batch.lock().unwrap();
         let cf = self.db.cf_handle(CF_MPT).unwrap();
         
         batch.put_cf(&cf, key, value);
         Ok(())
     }
 
-    // MPTからノードを削除する（メモリ上のWriteBatchに積むだけでSSDには書かない）
-    fn remove(&self, key: &[u8]) -> Result<(), DBError> {
-        let mut batch = self.batch.write().unwrap();
+    fn remove(&self, key: &[u8]) -> Result<(), Self::Error> {
+        // Mutex のロックを取得
+        let mut batch = self.batch.lock().unwrap();
         let cf = self.db.cf_handle(CF_MPT).unwrap();
         
         batch.delete_cf(&cf, key);
         Ok(())
     }
 
-    // CometBFTからのCommitシグナルを受け取った際に呼び出し、SSDへ一括書き込みを行う
-    fn flush(&self) -> Result<(), DBError> {
-        let mut batch = self.batch.write().unwrap();
+    fn flush(&self) -> Result<(), Self::Error> {
+        // Mutex のロックを取得
+        let mut batch = self.batch.lock().unwrap();
         
-        // 現在蓄積されているバッチを取り出し、メモリ上のバッチを空の初期状態にリセットする
+        // 現在のバッチを取り出し、空のバッチと入れ替える
         let current_batch = std::mem::replace(&mut *batch, WriteBatch::default());
         
-        // アトミックにSSDへ書き込む（途中でクラッシュしてもデータは破損しない）
-        self.db.write(current_batch).map_err(|e| DBError::Custom(e.to_string()))
+        // アトミックにSSDへ書き込み、Result をそのまま返す
+        self.db.write(current_batch)
     }
 }

--- a/src/leviathan/db.rs
+++ b/src/leviathan/db.rs
@@ -1,0 +1,71 @@
+use eth_trie::{DB as EthTrieDB, DBError};
+use rocksdb::{DB as RocksDB, Options, WriteBatch};
+use std::sync::{Arc, RwLock};
+
+// カラムファミリ名の定義
+pub const CF_MPT: &str = "mpt_data";
+pub const CF_CODE: &str = "code_data"; // 将来のコード永続化用に予約
+
+pub struct RocksDBWrapper {
+    db: Arc<RocksDB>,
+    // 内部可変性(Interior Mutability)を持たせ、&selfのままバッチを更新できるようにする
+    batch: RwLock<WriteBatch>,
+}
+
+impl RocksDBWrapper {
+    /// RocksDBインスタンスを初期化し、ラッパーを生成します
+    pub fn new(path: &str) -> Self {
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+        opts.create_missing_column_families(true);
+
+        // 使用するカラムファミリを宣言
+        let cfs = vec![CF_MPT, CF_CODE];
+        
+        // カラムファミリを有効にしてデータベースを開く
+        let db = RocksDB::open_cf(&opts, path, cfs).expect("RocksDBのオープンに失敗しました");
+        
+        Self { 
+            db: Arc::new(db),
+            batch: RwLock::new(WriteBatch::default()),
+        }
+    }
+}
+
+// eth_trie::DB トレイトの実装
+impl EthTrieDB for RocksDBWrapper {
+    // MPTからノードを読み込む（SSDから直接読み込み）
+    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, DBError> {
+        let cf = self.db.cf_handle(CF_MPT).unwrap();
+        self.db.get_cf(&cf, key).map_err(|e| DBError::Custom(e.to_string()))
+    }
+
+    // MPTに新しいノードを挿入する（メモリ上のWriteBatchに積むだけでSSDには書かない）
+    fn insert(&self, key: &[u8], value: Vec<u8>) -> Result<(), DBError> {
+        let mut batch = self.batch.write().unwrap();
+        let cf = self.db.cf_handle(CF_MPT).unwrap();
+        
+        batch.put_cf(&cf, key, value);
+        Ok(())
+    }
+
+    // MPTからノードを削除する（メモリ上のWriteBatchに積むだけでSSDには書かない）
+    fn remove(&self, key: &[u8]) -> Result<(), DBError> {
+        let mut batch = self.batch.write().unwrap();
+        let cf = self.db.cf_handle(CF_MPT).unwrap();
+        
+        batch.delete_cf(&cf, key);
+        Ok(())
+    }
+
+    // CometBFTからのCommitシグナルを受け取った際に呼び出し、SSDへ一括書き込みを行う
+    fn flush(&self) -> Result<(), DBError> {
+        let mut batch = self.batch.write().unwrap();
+        
+        // 現在蓄積されているバッチを取り出し、メモリ上のバッチを空の初期状態にリセットする
+        let current_batch = std::mem::replace(&mut *batch, WriteBatch::default());
+        
+        // アトミックにSSDへ書き込む（途中でクラッシュしてもデータは破損しない）
+        self.db.write(current_batch).map_err(|e| DBError::Custom(e.to_string()))
+    }
+}

--- a/src/leviathan/db.rs
+++ b/src/leviathan/db.rs
@@ -8,8 +8,7 @@ pub const CF_CODE: &str = "code_data";
 
 struct RocksDBInner {
     batch: WriteBatch,
-    // 🌟 テスト環境では、この overlay が実質的なメインDBとして機能する
-    overlay: HashMap<Vec<u8>, Vec<u8>>,
+    overlay: HashMap<Vec<u8>, Option<Vec<u8>>>,
 }
 
 pub struct RocksDBWrapper {
@@ -34,7 +33,33 @@ impl RocksDBWrapper {
             }),
         }
     }
+
+
+    pub fn insert_code(&self, code_hash: &[u8], code: &[u8]) {
+        let mut inner = self.inner.lock().unwrap();
+        let cf = self.db.cf_handle(CF_CODE).unwrap();
+        
+        inner.batch.put_cf(&cf, code_hash, code);
+        // overlayの型は Option<Vec<u8>> なので、Some で包んで入れる
+        inner.overlay.insert(code_hash.to_vec(), Some(code.to_vec()));
+    }
+
+    pub fn get_code(&self, code_hash: &[u8]) -> Option<Vec<u8>> {
+        let inner = self.inner.lock().unwrap();
+        
+        // 1. Overlayキャッシュを確認
+        if let Some(cache_result) = inner.overlay.get(code_hash) {
+            // cache_result は Option<Vec<u8>> なので、そのまま clone して返す
+            return cache_result.clone();
+        }
+        
+        // 2. キャッシュに無ければSSDを探す
+        let cf = self.db.cf_handle(CF_CODE).unwrap();
+        self.db.get_cf(&cf, code_hash).unwrap_or(None)
+    }
 }
+
+// --- MPT (eth_trie) 用メソッド ---
 
 impl EthTrieDB for RocksDBWrapper {
     type Error = RocksError;
@@ -42,13 +67,14 @@ impl EthTrieDB for RocksDBWrapper {
     fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
         let inner = self.inner.lock().unwrap();
 
-        // 🌟 常に Overlay キャッシュを最優先で確認！
-        // これにより、さっき insert したばかりのノードを確実に見つける
-        if let Some(value) = inner.overlay.get(key) {
-            return Ok(Some(value.clone()));
+        // 1. Overlayキャッシュを確認
+        if let Some(cache_result) = inner.overlay.get(key) {
+            // Some(Some(data)) -> 追加されたデータ
+            // Some(None) -> 削除されたデータ(Tombstone)
+            return Ok(cache_result.clone()); 
         }
 
-        // Overlay になければ、SSD(RocksDB本体)を探す
+        // 2. キャッシュに無ければSSDを探す
         let cf = self.db.cf_handle(CF_MPT).unwrap();
         self.db.get_cf(&cf, key)
     }
@@ -57,9 +83,9 @@ impl EthTrieDB for RocksDBWrapper {
         let mut inner = self.inner.lock().unwrap();
         let cf = self.db.cf_handle(CF_MPT).unwrap();
 
-        // バッチ(SSD書き込み予約)と Overlay(即時読み取り用) の両方に保存
+        // バッチにPutし、キャッシュには Some(value) として記録
         inner.batch.put_cf(&cf, key, &value);
-        inner.overlay.insert(key.to_vec(), value);
+        inner.overlay.insert(key.to_vec(), Some(value));
         Ok(())
     }
 
@@ -67,8 +93,9 @@ impl EthTrieDB for RocksDBWrapper {
         let mut inner = self.inner.lock().unwrap();
         let cf = self.db.cf_handle(CF_MPT).unwrap();
 
+        // 🌟 バッチにDeleteし、キャッシュには None (Tombstone) として記録
         inner.batch.delete_cf(&cf, key);
-        inner.overlay.remove(key);
+        inner.overlay.insert(key.to_vec(), None);
         Ok(())
     }
 
@@ -77,7 +104,7 @@ impl EthTrieDB for RocksDBWrapper {
         let current_batch = std::mem::replace(&mut inner.batch, WriteBatch::default());
         let result = self.db.write(current_batch);
 
-        // 🌟 SSD書き込み成功時に Overlay をクリアする
+        // SSD書き込み成功時に Overlay をクリアする
         if result.is_ok() {
             inner.overlay.clear();
         }

--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -8,7 +8,7 @@ use crate::leviathan::world_state::{Account, MptAccount, WorldState};
 use crate::my_trait::leviathan_trait::{
     ContractCreation, MessageCall, State, TransactionChecks, TransactionExecution,
 };
-use alloy_primitives::{Address, U256, hex, keccak256, TxKind};
+use alloy_primitives::{Address, TxKind, U256, hex, keccak256};
 use alloy_rlp::Encodable;
 use eth_trie::{EthTrie, Trie};
 use sha3::Digest;
@@ -130,13 +130,13 @@ impl TransactionExecution for LEVIATHAN {
             TxKind::Create => {
                 //デバック出力
                 tracing::info!(
-                    sender_address =  format_args!("0x{}", hex::encode(sender_address.0)),
-                    data = %hex::encode(&transaction.data),
-                    gas = %gas,
-                    gas_price = %transaction.t_price,
-                    send_eth = %transaction.t_value,
-                    "Transaction [CREATE]"
-                    );
+                sender_address =  format_args!("0x{}", hex::encode(sender_address.0)),
+                data = %hex::encode(&transaction.data),
+                gas = %gas,
+                gas_price = %transaction.t_price,
+                send_eth = %transaction.t_value,
+                "Transaction [CREATE]"
+                );
                 self.contract_creation(
                     state,
                     &mut substate,
@@ -150,7 +150,7 @@ impl TransactionExecution for LEVIATHAN {
                     None,
                     true,
                     block_header,
-                    )
+                )
             }
 
             TxKind::Call(to_address) => {
@@ -158,14 +158,14 @@ impl TransactionExecution for LEVIATHAN {
                 substate.a_touch.push(to_address.clone());
                 //デバック出力
                 tracing::info!(
-                    sender_address =  format_args!("0x{}", hex::encode(sender_address.0)),
-                    to_address =  format_args!("0x{}", hex::encode(to_address.0)),
-                    data = %hex::encode(&transaction.data),
-                    gas = %gas,
-                    gas_price = %transaction.t_price,
-                    send_eth = %transaction.t_value,
-                    "Transaction [CALL]"
-                    );
+                sender_address =  format_args!("0x{}", hex::encode(sender_address.0)),
+                to_address =  format_args!("0x{}", hex::encode(to_address.0)),
+                data = %hex::encode(&transaction.data),
+                gas = %gas,
+                gas_price = %transaction.t_price,
+                send_eth = %transaction.t_value,
+                "Transaction [CALL]"
+                );
                 self.message_call(
                     state,
                     &mut substate,
@@ -181,7 +181,7 @@ impl TransactionExecution for LEVIATHAN {
                     0,
                     true,
                     block_header,
-                    )
+                )
             }
         };
 

--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -290,10 +290,9 @@ impl TransactionExecution for LEVIATHAN {
                     };
                     //コードハッシュを取得
                     let code_hash = keccak256(cache_account.code.clone());
-                    state
-                        .code_storage
-                        .entry(code_hash)
-                        .or_insert(cache_account.code.clone());
+                    if state.data.get_code(code_hash.as_slice()).is_none() {
+                        state.data.insert_code(code_hash.as_slice(), &cache_account.code);
+                    }
                     tracing::info!(
                     address =  format_args!("0x{}", hex::encode(address.0)),
                     nonce = %cache_account.nonce,
@@ -438,10 +437,9 @@ impl TransactionExecution for LEVIATHAN {
                     };
                     //コードハッシュを取得
                     let code_hash = keccak256(cache_account.code.clone());
-                    state
-                        .code_storage
-                        .entry(code_hash)
-                        .or_insert(cache_account.code.clone());
+                    if state.data.get_code(code_hash.as_slice()).is_none() {
+                        state.data.insert_code(code_hash.as_slice(), &cache_account.code);
+                    }
                     let mpt_account = MptAccount::new(
                         cache_account.nonce,
                         cache_account.balance,

--- a/src/leviathan/leviathan.rs
+++ b/src/leviathan/leviathan.rs
@@ -8,7 +8,7 @@ use crate::leviathan::world_state::{Account, MptAccount, WorldState};
 use crate::my_trait::leviathan_trait::{
     ContractCreation, MessageCall, State, TransactionChecks, TransactionExecution,
 };
-use alloy_primitives::{Address, U256, hex, keccak256};
+use alloy_primitives::{Address, U256, hex, keccak256, TxKind};
 use alloy_rlp::Encodable;
 use eth_trie::{EthTrie, Trie};
 use sha3::Digest;
@@ -73,7 +73,7 @@ impl TransactionExecution for LEVIATHAN {
         }
 
         let mut contract_gas = U256::ZERO;
-        if transaction.t_to.is_none() {
+        if let TxKind::Create = transaction.t_to {
             //コントラクト作成追加費
             if self.version >= VersionId::Homestead {
                 //Homestead以降
@@ -126,60 +126,63 @@ impl TransactionExecution for LEVIATHAN {
         gas = gas.saturating_sub(all_gas);
 
         //=======ステップ3===========
-        let result = if transaction.t_to.is_none() {
-            //デバック出力
-            tracing::info!(
-            sender_address =  format_args!("0x{}", hex::encode(sender_address.0)),
-            data = %hex::encode(&transaction.data),
-            gas = %gas,
-            gas_price = %transaction.t_price,
-            send_eth = %transaction.t_value,
-            "Transaction [CREATE]"
-            );
-            self.contract_creation(
-                state,
-                &mut substate,
-                sender_address.clone(),
-                sender_address.clone(),
-                gas,
-                transaction.t_price,
-                transaction.t_value,
-                transaction.data,
-                0,
-                None,
-                true,
-                block_header,
-            )
-        } else {
-            let to_address = transaction.t_to.unwrap();
-            //a_touchにトランザクションの基本要素（宛先）を追加
-            substate.a_touch.push(to_address.clone());
-            //デバック出力
-            tracing::info!(
-            sender_address =  format_args!("0x{}", hex::encode(sender_address.0)),
-            to_address =  format_args!("0x{}", hex::encode(to_address.0)),
-            data = %hex::encode(&transaction.data),
-            gas = %gas,
-            gas_price = %transaction.t_price,
-            send_eth = %transaction.t_value,
-            "Transaction [CALL]"
-            );
-            self.message_call(
-                state,
-                &mut substate,
-                sender_address.clone(),
-                sender_address.clone(),
-                to_address.clone(),
-                to_address.clone(),
-                gas,
-                transaction.t_price,
-                transaction.t_value,
-                transaction.t_value,
-                transaction.data,
-                0,
-                true,
-                block_header,
-            )
+        let result = match transaction.t_to {
+            TxKind::Create => {
+                //デバック出力
+                tracing::info!(
+                    sender_address =  format_args!("0x{}", hex::encode(sender_address.0)),
+                    data = %hex::encode(&transaction.data),
+                    gas = %gas,
+                    gas_price = %transaction.t_price,
+                    send_eth = %transaction.t_value,
+                    "Transaction [CREATE]"
+                    );
+                self.contract_creation(
+                    state,
+                    &mut substate,
+                    sender_address.clone(),
+                    sender_address.clone(),
+                    gas,
+                    transaction.t_price,
+                    transaction.t_value,
+                    transaction.data,
+                    0,
+                    None,
+                    true,
+                    block_header,
+                    )
+            }
+
+            TxKind::Call(to_address) => {
+                //a_touchにトランザクションの基本要素（宛先）を追加
+                substate.a_touch.push(to_address.clone());
+                //デバック出力
+                tracing::info!(
+                    sender_address =  format_args!("0x{}", hex::encode(sender_address.0)),
+                    to_address =  format_args!("0x{}", hex::encode(to_address.0)),
+                    data = %hex::encode(&transaction.data),
+                    gas = %gas,
+                    gas_price = %transaction.t_price,
+                    send_eth = %transaction.t_value,
+                    "Transaction [CALL]"
+                    );
+                self.message_call(
+                    state,
+                    &mut substate,
+                    sender_address.clone(),
+                    sender_address.clone(),
+                    to_address.clone(),
+                    to_address.clone(),
+                    gas,
+                    transaction.t_price,
+                    transaction.t_value,
+                    transaction.t_value,
+                    transaction.data,
+                    0,
+                    true,
+                    block_header,
+                    )
+            }
         };
 
         //払い戻しガス

--- a/src/leviathan/mod.rs
+++ b/src/leviathan/mod.rs
@@ -1,5 +1,6 @@
 pub mod call;
 pub mod create;
+pub mod db;
 pub mod leviathan;
 pub mod mpt_method;
 pub mod my_precompiled;
@@ -8,4 +9,3 @@ pub mod roleback;
 pub mod structs;
 pub mod transaction_check;
 pub mod world_state;
-pub mod db;

--- a/src/leviathan/mod.rs
+++ b/src/leviathan/mod.rs
@@ -8,3 +8,4 @@ pub mod roleback;
 pub mod structs;
 pub mod transaction_check;
 pub mod world_state;
+pub mod db;

--- a/src/leviathan/mpt_method.rs
+++ b/src/leviathan/mpt_method.rs
@@ -125,11 +125,7 @@ impl State for WorldState {
             return None;
         };
         self.add_cache(address, &mpt_account);
-        let code = self
-            .code_storage
-            .get(&mpt_account.code_hash)
-            .cloned()
-            .unwrap();
+        let code = self.data.get_code(mpt_account.code_hash.as_slice()).unwrap_or_default();
         Some(code)
     }
 

--- a/src/leviathan/structs.rs
+++ b/src/leviathan/structs.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use alloy_primitives::{Address, U256, TxKind};
+use alloy_primitives::{Address, TxKind, U256};
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]

--- a/src/leviathan/structs.rs
+++ b/src/leviathan/structs.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use alloy_primitives::{Address, U256};
+use alloy_primitives::{Address, U256, TxKind};
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -25,7 +25,7 @@ pub struct Transaction {
     pub t_nonce: usize,
     pub t_gas_limit: U256,
     pub t_price: U256,
-    pub t_to: Option<Address>,
+    pub t_to: TxKind,
     pub t_value: U256,
     pub data: Vec<u8>,
     pub t_r: U256,

--- a/src/leviathan/structs.rs
+++ b/src/leviathan/structs.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 use alloy_primitives::{Address, TxKind, U256};
+use alloy_rlp::{RlpDecodable, RlpEncodable};
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -21,6 +22,7 @@ pub enum VersionId {
     Latest,
 }
 
+#[derive(Debug, Clone, RlpDecodable, RlpEncodable)]
 pub struct Transaction {
     pub t_nonce: usize,
     pub t_gas_limit: U256,

--- a/src/leviathan/transaction_check.rs
+++ b/src/leviathan/transaction_check.rs
@@ -4,7 +4,7 @@ use crate::leviathan::leviathan::LEVIATHAN;
 use crate::leviathan::structs::{BlockHeader, Transaction, VersionId};
 use crate::leviathan::world_state::WorldState;
 use crate::my_trait::leviathan_trait::{State, TransactionChecks};
-use alloy_primitives::{Address, U256, TxKind};
+use alloy_primitives::{Address, TxKind, U256};
 use alloy_rlp::{Encodable, Header};
 use bytes::BytesMut;
 use secp256k1::{

--- a/src/leviathan/transaction_check.rs
+++ b/src/leviathan/transaction_check.rs
@@ -4,7 +4,7 @@ use crate::leviathan::leviathan::LEVIATHAN;
 use crate::leviathan::structs::{BlockHeader, Transaction, VersionId};
 use crate::leviathan::world_state::WorldState;
 use crate::my_trait::leviathan_trait::{State, TransactionChecks};
-use alloy_primitives::{Address, U256};
+use alloy_primitives::{Address, U256, TxKind};
 use alloy_rlp::{Encodable, Header};
 use bytes::BytesMut;
 use secp256k1::{
@@ -29,8 +29,8 @@ impl TransactionChecks for LEVIATHAN {
         payload_length += transaction.t_gas_limit.length();
 
         let to_slice = match &transaction.t_to {
-            Some(address) => address.0.as_slice(),
-            None => &[], // 空のバイト列
+            TxKind::Call(address) => address.0.as_slice(),
+            TxKind::Create => &[], // 空のバイト列
         };
         payload_length += to_slice.length();
         payload_length += transaction.t_value.length();
@@ -112,7 +112,7 @@ impl TransactionChecks for LEVIATHAN {
         //Initコードが49152バイト以下
         if self.version >= VersionId::Shanghai {
             //Shanghai以降
-            if transaction.t_to.is_none() && transaction.data.len() > 49152 {
+            if transaction.t_to.is_create() && transaction.data.len() > 49152 {
                 return Err("Initコードが49152バイトを超えている");
             }
         }

--- a/src/leviathan/world_state.rs
+++ b/src/leviathan/world_state.rs
@@ -7,6 +7,9 @@ use sha3::Digest;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+
+use crate::leviathan::db::RocksDBWrapper;
+
 // 空のMPTツリーのルートハッシュ (Keccak256(RLP("")))
 pub const EMPTY_STORAGE_ROOT: B256 =
     b256!("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");
@@ -16,14 +19,15 @@ pub const EMPTY_CODE_HASH: B256 =
 
 pub struct WorldState {
     pub cache: HashMap<Address, Account>,
-    pub data: Arc<MemoryDB>,
-    pub eth_trie: EthTrie<MemoryDB>,
+    pub data: Arc<RocksDBWrapper>,
+    pub eth_trie: EthTrie<RocksDBWrapper>,
     pub code_storage: HashMap<B256, Vec<u8>>,
 }
 
 impl WorldState {
-    pub fn new() -> Self {
-        let data = Arc::new(MemoryDB::new(true));
+    pub fn new(db_path: &str) -> Self {
+        let db_wrapper = RocksDBWrapper::new(db_path);
+        let data = Arc::new(db_wrapper);
         let cache = HashMap::<Address, Account>::new();
         let mut eth_trie = EthTrie::new(data.clone());
         let _ = eth_trie.root_hash().unwrap();

--- a/src/leviathan/world_state.rs
+++ b/src/leviathan/world_state.rs
@@ -7,7 +7,6 @@ use sha3::Digest;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-
 use crate::leviathan::db::RocksDBWrapper;
 
 // 空のMPTツリーのルートハッシュ (Keccak256(RLP("")))

--- a/src/leviathan/world_state.rs
+++ b/src/leviathan/world_state.rs
@@ -20,7 +20,6 @@ pub struct WorldState {
     pub cache: HashMap<Address, Account>,
     pub data: Arc<RocksDBWrapper>,
     pub eth_trie: EthTrie<RocksDBWrapper>,
-    pub code_storage: HashMap<B256, Vec<u8>>,
 }
 
 impl WorldState {
@@ -35,12 +34,12 @@ impl WorldState {
         let empty_code = Vec::<u8>::new();
         let hash = keccak256(&empty_code);
         code_storage.insert(hash, empty_code);
+        data.insert_code(hash.as_slice(), &empty_code);
 
         Self {
             cache,
             data,
             eth_trie,
-            code_storage,
         }
     }
 
@@ -79,9 +78,9 @@ impl WorldState {
         };
         //コードハッシュを取得
         let code_hash = keccak256(cache_account.code.clone());
-        self.code_storage
-            .entry(code_hash)
-            .or_insert(cache_account.code.clone());
+        if self.data.get_code(code_hash.as_slice()).is_none() {
+            self.data.insert_code(code_hash.as_slice(), &cache_account.code);
+        }
         //mpt_accout作成
         let mpt_account = MptAccount::new(
             cache_account.nonce,
@@ -123,11 +122,7 @@ impl WorldState {
         let nonce = mpt_account.nonce;
         let balance = mpt_account.balance;
         let shash = mpt_account.storage_root;
-        let code = self
-            .code_storage
-            .get(&mpt_account.code_hash)
-            .cloned()
-            .unwrap();
+        let code = self.data.get_code(mpt_account.code_hash.as_slice()).expect("コードがDBに見つかりません");
         //mpt_accoutのhashを取得
         let mut mpt_account_rlp_bytes = Vec::new();
         mpt_account.encode(&mut mpt_account_rlp_bytes);

--- a/src/leviathan/world_state.rs
+++ b/src/leviathan/world_state.rs
@@ -33,7 +33,6 @@ impl WorldState {
         //空のコードのハッシュを登録
         let empty_code = Vec::<u8>::new();
         let hash = keccak256(&empty_code);
-        code_storage.insert(hash, empty_code);
         data.insert_code(hash.as_slice(), &empty_code);
 
         Self {

--- a/src/solidity_utils.rs
+++ b/src/solidity_utils.rs
@@ -3,7 +3,7 @@ use crate::leviathan::structs::{BlockHeader, Log, Transaction, VersionId};
 use crate::leviathan::world_state::{Account, WorldState};
 use crate::my_trait::leviathan_trait::{State, TransactionExecution};
 
-use alloy_primitives::{Address, Bytes, U256, hex, keccak256, uint};
+use alloy_primitives::{Address, Bytes, U256, hex, keccak256, uint, TxKind};
 use alloy_rlp::{Encodable, Header};
 use bytes::BytesMut;
 use secp256k1::{Message, Secp256k1, SecretKey};
@@ -107,7 +107,7 @@ pub fn deploy_contract(
 
     let transaction = Transaction {
         data: init_code,
-        t_to: None,
+        t_to: TxKind::Create,
         t_gas_limit: gas_limit,
         t_price: gas_price,
         t_value: eth,
@@ -196,7 +196,7 @@ pub fn call_contract(
 
     let transaction = Transaction {
         data,
-        t_to: Some(contract_addr),
+        t_to: TxKind::Call(contract_addr),
         t_gas_limit: gas_limit,
         t_price: gas_price,
         t_value: eth,
@@ -258,7 +258,7 @@ pub fn deploy_contract_raw(
 
     let transaction = Transaction {
         data: init_code,
-        t_to: None,
+        t_to: TxKind::Create,
         t_gas_limit: gas_limit,
         t_price: gas_price,
         t_value: eth,

--- a/src/solidity_utils.rs
+++ b/src/solidity_utils.rs
@@ -3,7 +3,7 @@ use crate::leviathan::structs::{BlockHeader, Log, Transaction, VersionId};
 use crate::leviathan::world_state::{Account, WorldState};
 use crate::my_trait::leviathan_trait::{State, TransactionExecution};
 
-use alloy_primitives::{Address, Bytes, U256, hex, keccak256, uint, TxKind};
+use alloy_primitives::{Address, Bytes, TxKind, U256, hex, keccak256, uint};
 use alloy_rlp::{Encodable, Header};
 use bytes::BytesMut;
 use secp256k1::{Message, Secp256k1, SecretKey};

--- a/tests/election_test.rs
+++ b/tests/election_test.rs
@@ -13,6 +13,7 @@ use leviathan_v2::leviathan::world_state::{Account, WorldState};
 use leviathan_v2::my_trait::leviathan_trait::State;
 use leviathan_v2::solidity_utils::{call_contract, deploy_contract, deploy_contract_raw};
 use leviathan_v2::zk_prover::ZkVotePayload;
+use tempfile::tempdir;
 
 sol! {
     function register(
@@ -136,7 +137,9 @@ fn test_election_e2e() {
 // =====================================================================
 
 fn setup_evm() -> (WorldState, LEVIATHAN, SecretKey, U256, U256) {
-    let mut state = WorldState::new();
+    let temp_dir = tempdir().expect("一時ディレクトリの作成に失敗しました");
+    let db_path = temp_dir.path().to_str().expect("無効なパスです");
+    let mut state = WorldState::new(db_path);
     let leviathan = LEVIATHAN::new(VersionId::Petersburg);
 
     let secret_key = SecretKey::from_byte_array(hex!(

--- a/tests/state_runner.rs
+++ b/tests/state_runner.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::io::Write;
 
 // alloy_primitives の hex を使用して E0433 を解消
-use alloy_primitives::{Address, U256, hex, keccak256};
+use alloy_primitives::{Address, TxKind, U256, hex, keccak256};
 
 // 署名生成のためのクレート
 use alloy_rlp::{Encodable, Header};
@@ -93,7 +93,7 @@ fn sign_transaction(
     nonce: U256,
     gas_price: U256,
     gas_limit: U256,
-    to: Option<Address>,
+    to: TxKind,
     value: U256,
     data: &[u8],
     secret_key_hex: &str,
@@ -105,8 +105,8 @@ fn sign_transaction(
     payload_length += gas_limit.length();
 
     let to_slice = match &to {
-        Some(addr) => addr.0.as_slice(),
-        None => &[], // 空のバイト列
+        TxKind::Call(addr) => addr.0.as_slice(),
+        TxKind::Create => &[], // 空のバイト列
     };
     payload_length += to_slice.length();
     payload_length += value.length();
@@ -406,9 +406,9 @@ fn state_test() {
                                     let gas_limit = parse_u256(gas_limit_str);
                                     let value = parse_u256(value_str);
                                     let to_address = if test_data.transaction.to.is_empty() {
-                                        None
+                                        TxKind::Create
                                     } else {
-                                        Some(parse_address(&test_data.transaction.to))
+                                        TxKind::Call(parse_address(&test_data.transaction.to))
                                     };
                                     let nonce = parse_u256(&test_data.transaction.nonce);
                                     let gas_price = parse_u256(&test_data.transaction.gas_price);

--- a/tests/state_runner.rs
+++ b/tests/state_runner.rs
@@ -359,7 +359,7 @@ fn state_test() {
                                             .unwrap_or_default();
 
                                         let code_hash = keccak256(&code);
-                                        state.code_storage.insert(code_hash, code.clone());
+                                        state.data.insert_code(code_hash.as_slice(), &code);
 
                                         let account = Account {
                                             nonce,

--- a/tests/state_runner.rs
+++ b/tests/state_runner.rs
@@ -11,6 +11,7 @@ use bytes::BytesMut;
 use eth_trie::{EthTrie, Trie};
 use secp256k1::{Message, Secp256k1, SecretKey};
 use sha3::{Digest, Keccak256};
+use tempfile::tempdir;
 
 // 🌟 crate:: ではなく パッケージ名 (ここでは leviathan_v2 と仮定) を使用します
 use leviathan_v2::leviathan::leviathan::LEVIATHAN; // LEVIATHAN を追加
@@ -305,9 +306,11 @@ fn state_test() {
                                         "  [Network: {:<17}] Matrix {} (data: {}, gas: {}, value: {})",
                                         network_str, post_idx, data_idx, gas_idx, value_idx
                                     );
-
+                                    
+                                    let temp_dir = tempdir().expect("一時ディレクトリの作成に失敗しました");
+                                    let db_path = temp_dir.path().to_str().expect("無効なパスです");
                                     // 1. WorldStateの初期化 (必ず毎ループ初期化する！)
-                                    let mut state = WorldState::new();
+                                    let mut state = WorldState::new(db_path);
 
                                     for (addr_str, acc_data) in &test_data.pre {
                                         let addr = parse_address(addr_str);

--- a/tests/state_runner.rs
+++ b/tests/state_runner.rs
@@ -306,8 +306,9 @@ fn state_test() {
                                         "  [Network: {:<17}] Matrix {} (data: {}, gas: {}, value: {})",
                                         network_str, post_idx, data_idx, gas_idx, value_idx
                                     );
-                                    
-                                    let temp_dir = tempdir().expect("一時ディレクトリの作成に失敗しました");
+
+                                    let temp_dir =
+                                        tempdir().expect("一時ディレクトリの作成に失敗しました");
                                     let db_path = temp_dir.path().to_str().expect("無効なパスです");
                                     // 1. WorldStateの初期化 (必ず毎ループ初期化する！)
                                     let mut state = WorldState::new(db_path);


### PR DESCRIPTION
## 概要 (Overview)
本PRは、Leviathanのステート管理レイヤー（StateDB）をインメモリ（`MemoryDB`）からSSD永続化可能な `RocksDB` へと完全に移行する大規模なアーキテクチャ刷新です。
CometBFTとの統合（アトミックなブロック確定）を見据えた遅延コミット（WriteBatc）と、トランザクション実行中の Read-Your-Writes（即時読み取り一貫性）を両立させる堅牢なインフラを構築しました。また、巨大なインメモリHashMapであった `code_storage` を廃止し、スマートコントラクトのバイトコードもRocksDBへ永続化するように最適化しました。

## 主な変更点 (Key Changes)

### RocksDBラッパーの実装とColumn Familyの導入 (`db.rs`)
* `eth_trie::DB` トレイトを実装した独自の `RocksDBWrapper` を新規作成しました。
* RocksDB内に2つのColumn Family (`mpt_data`, `code_data`) を定義し、MPTノードデータとコントラクトのバイトコードを論理的に分離して管理できるようにしました。
* スレッドセーフな設計とするため、WriteBatchのロック機構に `Mutex` を採用しています。

### OverlayキャッシュとTombstone（墓標）による一貫性保証 (`db.rs`)
* **課題:** `eth_trie` がノードを生成した直後にハッシュ計算のために再読み込みを行う際、遅延コミット（WriteBatch）仕様によりデータがSSDに存在せずパニック（`The root that was just created is missing`）になる問題がありました。
* **解決策:** `RocksDBWrapper` 内部に `HashMap<Vec<u8>, Option<Vec<u8>>>` による **Overlayキャッシュ** を実装しました。
* `Option` 型を用いた **Tombstone（墓標）パターン** を導入し、削除されたデータがSSDから復活するゾンビ問題を防止しつつ、メモリ上で完璧な一貫性を保ったままMPTの計算が完結するよう改善しました。

### スマートコントラクト・バイトコードのSSD永続化 (`world_state.rs`, `mpt_method.rs`)
* `WorldState` 構造体から、これまでメモリを圧迫していた `code_storage: HashMap<B256, Vec<u8>>` を完全に削除しました。
* バイトコードの読み書きを、`RocksDBWrapper` の `CF_CODE` を経由するように `mpt_method.rs` と `leviathan.rs` をリファクタリングしました。
* コードデータもMPTデータと同様に、トランザクション中はOverlayキャッシュに保持され、`flush()` 時にのみSSDへ書き込まれる安全なアーキテクチャに統一しました。

### テスト環境およびABCIノードの適応 (`state_runner.rs`, `abci_node.rs`, etc.)
* `state_runner.rs` における公式の StateTest 実行時、テストケース間で状態が衝突しないよう一時ディレクトリ（`tempfile`）を利用するクリーンな実行環境を整備しました。
* 各種テスト (`election_test` 等) および `abci_node` を新しい `WorldState` の仕様（引数へのDBパス追加、初期化ロジック）に適合させました。

## アーキテクチャの進化ポイント
* **トランザクション実行時（In-Memory）:** MPTの更新やコードの保存はすべてメモリ上の `WriteBatch` と `Overlay` キャッシュで完結するため、SSDへの物理I/Oペナルティや寿命の低下を防ぎ、早い計算が行われます。
* **ブロック確定時（Persistence）:** トランザクションが成功し、ノード（CometBFT）から `Commit` シグナルが来たタイミングで `flush()` が呼ばれ、計算結果がアトミックにSSDへ永続化されます。

## テスト結果 (Test Results)
* 公式のEthereum StateTest (`TestData/MPTTest/*`) をすべてパスすることを確認しました。
