### PR TITLE
feat: WorldStateにブロック高(block_number)フィールドと更新メソッドを追加

### DIFF
--- a/src/leviathan/world_state.rs
+++ b/src/leviathan/world_state.rs
@@ -20,10 +20,12 @@ pub struct WorldState {
     pub cache: HashMap<Address, Account>,
     pub data: Arc<RocksDBWrapper>,
     pub eth_trie: EthTrie<RocksDBWrapper>,
+    pub block_number: i64,
 }
 
 impl WorldState {
     pub fn new(db_path: &str) -> Self {
+        let block_number:i64 = 0;
         let db_wrapper = RocksDBWrapper::new(db_path);
         let data = Arc::new(db_wrapper);
         let cache = HashMap::<Address, Account>::new();
@@ -39,6 +41,7 @@ impl WorldState {
             cache,
             data,
             eth_trie,
+            block_number,
         }
     }
 
@@ -155,6 +158,10 @@ impl WorldState {
     pub fn update_eth_trie(&mut self, state_root: B256) {
         let new_eth_trie = EthTrie::from(self.data.clone(), state_root).unwrap();
         self.eth_trie = new_eth_trie;
+    }
+
+    pub fn update_block_number(&mut self, new_number: i64) {
+        self.block_number = new_number;
     }
 }
 


### PR DESCRIPTION
## 概要 (Overview)
EVMの実行状態を管理する WorldState 構造体に対して、現在のブロック高を保持・追跡できるように新しいフィールドを追加しました。

## 追加・変更内容 (Changes)

### フィールドの追加:
WorldState 構造体に block_number: i64 フィールドを新規追加しました。

 ### メソッドの実装:
ブロック進行に合わせて block_number を適切に更新するためのメソッドを実装しました。

## 検証結果 (Results)
state_runner を用いたEVMテストスイートを実行し、すべてのテストが正常にパスすることを確認しました。
今回のフィールドおよびメソッド追加に伴う、既存のステート遷移やトランザクション実行ロジックへの悪影響（デグレ）はありません。